### PR TITLE
Fixes an issue where html error pages returned from the server are written to a file.

### DIFF
--- a/src/com/koushikdutta/test/UrlImageViewHelper.java
+++ b/src/com/koushikdutta/test/UrlImageViewHelper.java
@@ -1,14 +1,5 @@
 package com.koushikdutta.test;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.Hashtable;
-
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -26,6 +17,16 @@ import android.os.AsyncTask;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.widget.ImageView;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.util.ArrayList;
+import java.util.Hashtable;
 
 public final class UrlImageViewHelper {
     private static final String LOGTAG = "UrlImageViewHelper";
@@ -183,6 +184,11 @@ public final class UrlImageViewHelper {
                     DefaultHttpClient client = new DefaultHttpClient();
                     HttpGet get = new HttpGet(url);
                     HttpResponse resp = client.execute(get);
+                    int status = resp.getStatusLine().getStatusCode();
+                    if(status != HttpURLConnection.HTTP_OK){
+                        Log.i(LOGTAG, "Couldn't download image from Server: " + url + " Reason: " + resp.getStatusLine().getReasonPhrase() + " / " + status);
+                        return null;
+                    }    
                     HttpEntity entity = resp.getEntity();
                     Log.i(LOGTAG, url + " Image Content Length: " + entity.getContentLength());
                     InputStream is = entity.getContent();


### PR DESCRIPTION
Added test to check if the server returned HTTP_OK when downloading the image.

This fix's an issue where an error occurs downloading the image, like a 404 Not Found & the InputStream is still written to the file. When this file is loaded as a drawable null is returned as the file doesn't contain an image, but the html error page that was returned.
