### PR TITLE
[Android > 3.0] Apps using this lib will crash on pressing the menu button

### DIFF
--- a/UrlImageViewHelper/src/com/koushikdutta/urlimageviewhelper/UrlImageViewHelper.java
+++ b/UrlImageViewHelper/src/com/koushikdutta/urlimageviewhelper/UrlImageViewHelper.java
@@ -55,7 +55,7 @@ public final class UrlImageViewHelper {
         Activity act = (Activity)context;
         act.getWindowManager().getDefaultDisplay().getMetrics(mMetrics);
         AssetManager mgr = context.getAssets();
-        mResources = new Resources(mgr, mMetrics, null);
+        mResources = new Resources(mgr, mMetrics, context.getResources().getConfiguration());
     }
 
     private static BitmapDrawable loadDrawableFromStream(Context context, InputStream stream) {


### PR DESCRIPTION
It seems that due to some changes in the Resources class there is some incompatibility after creating a new object with a null parameter as this lib does.
This will break the Android options menu.
