### PR TITLE
optimisation to limit out of memory when loading a lot of big internet picture

### DIFF
--- a/UrlImageViewHelper/src/com/koushikdutta/urlimageviewhelper/UrlImageViewHelper.java
+++ b/UrlImageViewHelper/src/com/koushikdutta/urlimageviewhelper/UrlImageViewHelper.java
@@ -68,14 +68,15 @@ public final class UrlImageViewHelper {
         BitmapFactory.decodeStream(stream,null,o);
 
         //Find the correct scale value. It should be the power of 2.
-        int width_tmp=o.outWidth, height_tmp=o.outHeight;
-        int scale=1;
-        while(true){
-            if(width_tmp/2<maxSize || height_tmp/2<maxSize)
+        int tmpWidth = o.outWidth;
+        int tmpHeight = o.outHeight;
+        int scale = 1;
+        while (true) {
+            if (tmpWidth / 2 < maxSize || tmpHeight / 2 < maxSize)
                 break;
-            width_tmp/=2;
-            height_tmp/=2;
-            scale*=2;
+            tmpWidth /= 2;
+            tmpHeight /= 2;
+            scale *= 2;
         }
         stream.close();
 
@@ -91,7 +92,7 @@ public final class UrlImageViewHelper {
     }
 
     public static final int CACHE_DURATION_INFINITE = Integer.MAX_VALUE;
-    public static final int MAX_DISPLAY_SIZE = 100;
+    public static final int MAX_DISPLAY_SIZE = 480;
     public static final int CACHE_DURATION_ONE_DAY = 1000 * 60 * 60 * 24;
     public static final int CACHE_DURATION_TWO_DAYS = CACHE_DURATION_ONE_DAY * 2;
     public static final int CACHE_DURATION_THREE_DAYS = CACHE_DURATION_ONE_DAY * 3;

--- a/UrlImageViewHelper/src/com/koushikdutta/urlimageviewhelper/UrlImageViewHelper.java
+++ b/UrlImageViewHelper/src/com/koushikdutta/urlimageviewhelper/UrlImageViewHelper.java
@@ -58,14 +58,40 @@ public final class UrlImageViewHelper {
         mResources = new Resources(mgr, mMetrics, context.getResources().getConfiguration());
     }
 
-    private static BitmapDrawable loadDrawableFromStream(Context context, InputStream stream) {
+    private static BitmapDrawable loadDrawableFromStream(Context context, String filename, int maxSize) throws IOException
+    {
+        FileInputStream  stream = context.openFileInput(filename);
         prepareResources(context);
-        final Bitmap bitmap = BitmapFactory.decodeStream(stream);
+
+        BitmapFactory.Options o = new BitmapFactory.Options();
+        o.inJustDecodeBounds = true;
+        BitmapFactory.decodeStream(stream,null,o);
+
+        //Find the correct scale value. It should be the power of 2.
+        int width_tmp=o.outWidth, height_tmp=o.outHeight;
+        int scale=1;
+        while(true){
+            if(width_tmp/2<maxSize || height_tmp/2<maxSize)
+                break;
+            width_tmp/=2;
+            height_tmp/=2;
+            scale*=2;
+        }
+        stream.close();
+
+        //decode with inSampleSize
+        BitmapFactory.Options o2 = new BitmapFactory.Options();
+        o2.inSampleSize=scale;
+
+        stream = context.openFileInput(filename);
+        final Bitmap bitmap = BitmapFactory.decodeStream(stream, null, o2);
+        stream.close();
         //Log.i(LOGTAG, String.format("Loaded bitmap (%dx%d).", bitmap.getWidth(), bitmap.getHeight()));
         return new BitmapDrawable(mResources, bitmap);
     }
 
     public static final int CACHE_DURATION_INFINITE = Integer.MAX_VALUE;
+    public static final int MAX_DISPLAY_SIZE = 100;
     public static final int CACHE_DURATION_ONE_DAY = 1000 * 60 * 60 * 24;
     public static final int CACHE_DURATION_TWO_DAYS = CACHE_DURATION_ONE_DAY * 2;
     public static final int CACHE_DURATION_THREE_DAYS = CACHE_DURATION_ONE_DAY * 3;
@@ -75,73 +101,77 @@ public final class UrlImageViewHelper {
     public static final int CACHE_DURATION_ONE_WEEK = CACHE_DURATION_ONE_DAY * 7;
 
     public static void setUrlDrawable(final ImageView imageView, final String url, int defaultResource) {
-        setUrlDrawable(imageView.getContext(), imageView, url, defaultResource, CACHE_DURATION_THREE_DAYS);
+        setUrlDrawable(imageView.getContext(), imageView, url, defaultResource, CACHE_DURATION_THREE_DAYS, MAX_DISPLAY_SIZE);
+    }
+
+    public static void setUrlDrawable(final ImageView imageView, final String url, int defaultResource, int maxSize) {
+        setUrlDrawable(imageView.getContext(), imageView, url, defaultResource, CACHE_DURATION_THREE_DAYS, maxSize);
     }
 
     public static void setUrlDrawable(final ImageView imageView, final String url) {
-        setUrlDrawable(imageView.getContext(), imageView, url, null, CACHE_DURATION_THREE_DAYS, null);
+        setUrlDrawable(imageView.getContext(), imageView, url, null, CACHE_DURATION_THREE_DAYS, MAX_DISPLAY_SIZE, null);
     }
 
-    public static void loadUrlDrawable(final Context context, final String url) {
-        setUrlDrawable(context, null, url, null, CACHE_DURATION_THREE_DAYS, null);
+    public static void loadUrlDrawable(final Context context, final String url, int maxSize) {
+        setUrlDrawable(context, null, url, null, CACHE_DURATION_THREE_DAYS, maxSize, null);
     }
 
-    public static void setUrlDrawable(final ImageView imageView, final String url, Drawable defaultDrawable) {
-        setUrlDrawable(imageView.getContext(), imageView, url, defaultDrawable, CACHE_DURATION_THREE_DAYS, null);
+    public static void setUrlDrawable(final ImageView imageView, final String url, Drawable defaultDrawable, int maxSize) {
+        setUrlDrawable(imageView.getContext(), imageView, url, defaultDrawable, CACHE_DURATION_THREE_DAYS, maxSize, null);
     }
 
-    public static void setUrlDrawable(final ImageView imageView, final String url, int defaultResource, long cacheDurationMs) {
-        setUrlDrawable(imageView.getContext(), imageView, url, defaultResource, cacheDurationMs);
+    public static void setUrlDrawable(final ImageView imageView, final String url, int defaultResource, long cacheDurationMs, int maxSize ) {
+        setUrlDrawable(imageView.getContext(), imageView, url, defaultResource, cacheDurationMs, maxSize);
     }
 
-    public static void loadUrlDrawable(final Context context, final String url, long cacheDurationMs) {
-        setUrlDrawable(context, null, url, null, cacheDurationMs, null);
+    public static void loadUrlDrawable(final Context context, final String url, long cacheDurationMs, int maxSize) {
+        setUrlDrawable(context, null, url, null, cacheDurationMs, maxSize, null);
     }
 
-    public static void setUrlDrawable(final ImageView imageView, final String url, Drawable defaultDrawable, long cacheDurationMs) {
-        setUrlDrawable(imageView.getContext(), imageView, url, defaultDrawable, cacheDurationMs, null);
+    public static void setUrlDrawable(final ImageView imageView, final String url, Drawable defaultDrawable, long cacheDurationMs, int maxSize) {
+        setUrlDrawable(imageView.getContext(), imageView, url, defaultDrawable, cacheDurationMs, maxSize, null);
     }
 
-    private static void setUrlDrawable(final Context context, final ImageView imageView, final String url, int defaultResource, long cacheDurationMs) {
+    private static void setUrlDrawable(final Context context, final ImageView imageView, final String url, int defaultResource, long cacheDurationMs, int maxSize) {
         Drawable d = null;
         if (defaultResource != 0)
             d = imageView.getResources().getDrawable(defaultResource);
-        setUrlDrawable(context, imageView, url, d, cacheDurationMs, null);
+        setUrlDrawable(context, imageView, url, d, cacheDurationMs, maxSize, null);
     }
 
-    public static void setUrlDrawable(final ImageView imageView, final String url, int defaultResource, UrlImageViewCallback callback) {
-        setUrlDrawable(imageView.getContext(), imageView, url, defaultResource, CACHE_DURATION_THREE_DAYS, callback);
+    public static void setUrlDrawable(final ImageView imageView, final String url, int defaultResource, int maxSize, UrlImageViewCallback callback) {
+        setUrlDrawable(imageView.getContext(), imageView, url, defaultResource, CACHE_DURATION_THREE_DAYS, maxSize, callback);
     }
 
-    public static void setUrlDrawable(final ImageView imageView, final String url, UrlImageViewCallback callback) {
-        setUrlDrawable(imageView.getContext(), imageView, url, null, CACHE_DURATION_THREE_DAYS, callback);
+    public static void setUrlDrawable(final ImageView imageView, final String url, int maxSize, UrlImageViewCallback callback) {
+        setUrlDrawable(imageView.getContext(), imageView, url, null, CACHE_DURATION_THREE_DAYS, maxSize, callback);
     }
 
-    public static void loadUrlDrawable(final Context context, final String url, UrlImageViewCallback callback) {
-        setUrlDrawable(context, null, url, null, CACHE_DURATION_THREE_DAYS, callback);
+    public static void loadUrlDrawable(final Context context, final String url, int maxSize, UrlImageViewCallback callback) {
+        setUrlDrawable(context, null, url, null, CACHE_DURATION_THREE_DAYS, maxSize, callback);
     }
 
-    public static void setUrlDrawable(final ImageView imageView, final String url, Drawable defaultDrawable, UrlImageViewCallback callback) {
-        setUrlDrawable(imageView.getContext(), imageView, url, defaultDrawable, CACHE_DURATION_THREE_DAYS, callback);
+    public static void setUrlDrawable(final ImageView imageView, final String url, Drawable defaultDrawable, int maxSize, UrlImageViewCallback callback) {
+        setUrlDrawable(imageView.getContext(), imageView, url, defaultDrawable, CACHE_DURATION_THREE_DAYS, maxSize, callback);
     }
 
-    public static void setUrlDrawable(final ImageView imageView, final String url, int defaultResource, long cacheDurationMs, UrlImageViewCallback callback) {
-        setUrlDrawable(imageView.getContext(), imageView, url, defaultResource, cacheDurationMs, callback);
+    public static void setUrlDrawable(final ImageView imageView, final String url, int defaultResource, long cacheDurationMs, int maxSize, UrlImageViewCallback callback) {
+        setUrlDrawable(imageView.getContext(), imageView, url, defaultResource, cacheDurationMs, maxSize, callback);
     }
 
-    public static void loadUrlDrawable(final Context context, final String url, long cacheDurationMs, UrlImageViewCallback callback) {
-        setUrlDrawable(context, null, url, null, cacheDurationMs, callback);
+    public static void loadUrlDrawable(final Context context, final String url, long cacheDurationMs, int maxSize, UrlImageViewCallback callback) {
+        setUrlDrawable(context, null, url, null, cacheDurationMs, maxSize, callback);
     }
 
-    public static void setUrlDrawable(final ImageView imageView, final String url, Drawable defaultDrawable, long cacheDurationMs, UrlImageViewCallback callback) {
-        setUrlDrawable(imageView.getContext(), imageView, url, defaultDrawable, cacheDurationMs, callback);
+    public static void setUrlDrawable(final ImageView imageView, final String url, Drawable defaultDrawable, long cacheDurationMs, int maxSize, UrlImageViewCallback callback) {
+        setUrlDrawable(imageView.getContext(), imageView, url, defaultDrawable, cacheDurationMs, maxSize, callback);
     }
 
-    private static void setUrlDrawable(final Context context, final ImageView imageView, final String url, int defaultResource, long cacheDurationMs, UrlImageViewCallback callback) {
+    private static void setUrlDrawable(final Context context, final ImageView imageView, final String url, int defaultResource, long cacheDurationMs, int maxSize, UrlImageViewCallback callback) {
         Drawable d = null;
         if (defaultResource != 0)
             d = imageView.getResources().getDrawable(defaultResource);
-        setUrlDrawable(context, imageView, url, d, cacheDurationMs, callback);
+        setUrlDrawable(context, imageView, url, d, cacheDurationMs, maxSize, callback);
     }
 
     private static boolean isNullOrEmpty(CharSequence s) {
@@ -177,7 +207,7 @@ public final class UrlImageViewHelper {
         }
     }
 
-    private static void setUrlDrawable(final Context context, final ImageView imageView, final String url, final Drawable defaultDrawable, long cacheDurationMs, final UrlImageViewCallback callback) {
+    private static void setUrlDrawable(final Context context, final ImageView imageView, final String url, final Drawable defaultDrawable, long cacheDurationMs, final int maxSize, final UrlImageViewCallback callback) {
         cleanup(context);
         // disassociate this ImageView from any pending downloads
         if (imageView != null)
@@ -207,9 +237,7 @@ public final class UrlImageViewHelper {
             try {
                 if (cacheDurationMs == CACHE_DURATION_INFINITE || System.currentTimeMillis() < file.lastModified() + cacheDurationMs) {
                     //Log.i(LOGTAG, "File Cache hit on: " + url + ". " + (System.currentTimeMillis() - file.lastModified()) + "ms old.");
-                    FileInputStream  fis = context.openFileInput(filename);
-                    drawable = loadDrawableFromStream(context, fis);
-                    fis.close();
+                    drawable = loadDrawableFromStream(context, filename, maxSize);
                     if (imageView != null)
                         imageView.setImageDrawable(drawable);
                     cache.put(url, drawable);
@@ -275,8 +303,7 @@ public final class UrlImageViewHelper {
                     copyStream(is, fos);
                     fos.close();
                     is.close();
-                    FileInputStream  fis = context.openFileInput(filename);
-                    return loadDrawableFromStream(context, fis);
+                    return loadDrawableFromStream(context, filename, maxSize);
                 }
                 catch (Exception ex) {
 //                    Log.e(LOGTAG, "Exception during Image download of " + url, ex);
@@ -302,9 +329,7 @@ public final class UrlImageViewHelper {
                     }
                     mPendingViews.remove(iv);
                     if (usableResult != null) {
-                        final Drawable newImage = usableResult;
-                        final ImageView imageView = iv;
-                        imageView.setImageDrawable(newImage);
+                        iv.setImageDrawable(usableResult);
                         if (callback != null)
                             callback.onLoaded(imageView, result, url, false);
                     }


### PR DESCRIPTION
When using this helper for a lot of pictures that are not mobile
optimized won get an out of memory very fast.
The trick is to display a scaled down image.

By default, images have a MAX_DISPLAY_SIZE of 100
so if you load an image that is 2000x2000 pixel big, it will be shown
as a 100x100 picture.

The setUrlDrawable methods also offer the ability to set an other value
if desired
