### PR TITLE
Added minimal formatting changes, got rid of a couple of warnings, added documentation.

### DIFF
--- a/UrlImageViewHelper/src/com/koushikdutta/urlimageviewhelper/UrlImageViewHelper.java
+++ b/UrlImageViewHelper/src/com/koushikdutta/urlimageviewhelper/UrlImageViewHelper.java
@@ -35,285 +35,15 @@ import android.os.Looper;
 import android.provider.ContactsContract;
 import android.util.DisplayMetrics;
 import android.util.Log;
+import android.view.Display;
+import android.view.WindowManager;
 import android.widget.ImageView;
 
 public final class UrlImageViewHelper {
-    
-    private static final class AsyncLoadFileTask extends
-            AsyncTask<Void, Void, Void> {
-        private final Loader loader;
-        private final Runnable completion;
-        
-        private AsyncLoadFileTask(final Loader loader, final Runnable completion) {
-            this.loader = loader;
-            this.completion = completion;
-        }
-        
-        @Override
-        protected Void doInBackground(final Void... params) {
-            loader.run();
-            return null;
-        }
-        
-        @Override
-        protected void onPostExecute(final Void result) {
-            completion.run();
-        }
-    }
-    
-    private static final class DefaultLoader extends Loader {
-        private final Context context;
-        private final String filename;
-        private final int targetWidth;
-        private final int targetHeight;
-        private final String url;
-        
-        private DefaultLoader(final Context context, final String filename,
-                final int targetWidth, final int targetHeight, final String url) {
-            this.context = context;
-            this.filename = filename;
-            this.targetWidth = targetWidth;
-            this.targetHeight = targetHeight;
-            this.url = url;
-        }
-        
-        @Override
-        public void run() {
-            try {
-                result = loadDrawableFromStream(context, url, filename,
-                        targetWidth, targetHeight);
-            } catch (final Exception ex) {
-            }
-        }
-    }
-    
-    private static abstract class Loader implements Runnable {
-        public Drawable result;
-    }
-    
-    private static final class OnImageLoadRunnable implements Runnable {
-        private final String url;
-        private final Loader loader;
-        private final ArrayList<ImageView> downloads;
-        private final UrlImageViewCallback callback;
-        private final Drawable defaultDrawable;
-        
-        private OnImageLoadRunnable(final String url, final Loader loader,
-                final ArrayList<ImageView> downloads,
-                final UrlImageViewCallback callback,
-                final Drawable defaultDrawable) {
-            this.url = url;
-            this.loader = loader;
-            this.downloads = downloads;
-            this.callback = callback;
-            this.defaultDrawable = defaultDrawable;
-        }
-        
-        @Override
-        public void run() {
-            Assert.assertEquals(Looper.myLooper(), Looper
-                    .getMainLooper());
-            Drawable usableResult = loader.result;
-            if (usableResult == null) {
-                usableResult = defaultDrawable;
-            }
-            mPendingDownloads.remove(url);
-            mLiveCache.put(url, usableResult);
-            for (final ImageView iv : downloads) {
-                // validate the url it is waiting for
-                final String pendingUrl = mPendingViews.get(iv);
-                if (!url.equals(pendingUrl)) {
-                    if (Constants.LOG_ENABLED) {
-                        Log.i(Constants.LOGTAG,
-                                "Ignoring out of date request to update view for "
-                                        + url);
-                    }
-                    continue;
-                }
-                mPendingViews.remove(iv);
-                if (usableResult != null) {
-                    // System.out.println(String.format("imageView: %dx%d, %dx%d",
-                    // imageView.getMeasuredWidth(),
-                    // imageView.getMeasuredHeight(),
-                    // imageView.getWidth(),
-                    // imageView.getHeight()));
-                    iv.setImageDrawable(usableResult);
-                    // System.out.println(String.format("imageView: %dx%d, %dx%d",
-                    // imageView.getMeasuredWidth(),
-                    // imageView.getMeasuredHeight(),
-                    // imageView.getWidth(),
-                    // imageView.getHeight()));
-                    if (callback != null) {
-                        callback.onLoaded(iv, loader.result, url, false);
-                    }
-                }
-            }
-        }
-    }
-    
-    static public interface RequestPropertiesCallback {
-        public ArrayList<NameValuePair> getHeadersForRequest(Context context,
-                String url);
-    }
-    
-    public static interface UrlDownloader {
-        public void download(Context context, String url, String filename,
-                Runnable loader, Runnable completion);
-    }
-    
-    private static class ZombieDrawable extends WrapperDrawable {
-        String mUrl;
-        
-        public ZombieDrawable(final String url, final BitmapDrawable drawable) {
-            super(drawable);
-            mUrl = url;
-            
-            mAllCache.add(drawable);
-            mDeadCache.remove(url);
-            mLiveCache.put(url, this);
-        }
-        
-        @Override
-        protected void finalize() throws Throwable {
-            super.finalize();
-            
-            mDeadCache.put(mUrl, mDrawable);
-            mAllCache.remove(mDrawable);
-            mLiveCache.remove(mUrl);
-            if (Constants.LOG_ENABLED) {
-                Log.i(Constants.LOGTAG, "Zombie GC event");
-            }
-            System.gc();
-        }
-    }
-    
-    static Resources mResources;
-    
-    static DisplayMetrics mMetrics;
-    public static final int CACHE_DURATION_INFINITE = Integer.MAX_VALUE;
-    public static final int CACHE_DURATION_ONE_DAY = 1000 * 60 * 60 * 24;
-    public static final int CACHE_DURATION_TWO_DAYS = CACHE_DURATION_ONE_DAY * 2;
-    public static final int CACHE_DURATION_THREE_DAYS = CACHE_DURATION_ONE_DAY * 3;
-    public static final int CACHE_DURATION_FOUR_DAYS = CACHE_DURATION_ONE_DAY * 4;
-    public static final int CACHE_DURATION_FIVE_DAYS = CACHE_DURATION_ONE_DAY * 5;
-    public static final int CACHE_DURATION_SIX_DAYS = CACHE_DURATION_ONE_DAY * 6;
-    
-    public static final int CACHE_DURATION_ONE_WEEK = CACHE_DURATION_ONE_DAY * 7;
-    
-    private static boolean mHasCleaned = false;
-    
-    private static UrlDownloader mDefaultDownloader = new UrlDownloader() {
-        @Override
-        public void download(final Context context, final String url,
-                final String filename, final Runnable loader,
-                final Runnable completion) {
-            final AsyncTask<Void, Void, Void> downloader = new AsyncTask<Void, Void, Void>() {
-                @Override
-                protected Void doInBackground(final Void... params) {
-                    try {
-                        InputStream is = null;
-                        if (url.startsWith(ContactsContract.Contacts.CONTENT_URI
-                                .toString())) {
-                            final ContentResolver cr = context
-                                    .getContentResolver();
-                            is = ContactsContract.Contacts
-                                    .openContactPhotoInputStream(cr, Uri
-                                            .parse(url));
-                        }
-                        else {
-                            final URL u = new URL(url);
-                            final HttpURLConnection urlConnection = (HttpURLConnection) u
-                                    .openConnection();
-                            
-                            if (mRequestPropertiesCallback != null) {
-                                final ArrayList<NameValuePair> props = mRequestPropertiesCallback
-                                        .getHeadersForRequest(context, url);
-                                if (props != null) {
-                                    for (final NameValuePair pair : props) {
-                                        urlConnection.addRequestProperty(pair
-                                                .getName(), pair.getValue());
-                                    }
-                                }
-                            }
-                            
-                            if (urlConnection.getResponseCode() != HttpURLConnection.HTTP_OK) {
-                                return null;
-                            }
-                            is = urlConnection.getInputStream();
-                        }
-                        
-                        if (is != null) {
-                            final FileOutputStream fos = new FileOutputStream(
-                                    filename);
-                            copyStream(is, fos);
-                            fos.close();
-                            is.close();
-                        }
-                        loader.run();
-                        return null;
-                    }
-                    catch (final Throwable e) {
-                        e.printStackTrace();
-                        return null;
-                    }
-                }
-                
-                @Override
-                protected void onPostExecute(final Void result) {
-                    completion.run();
-                }
-            };
-            
-            executeTask(downloader);
-        }
-    };
-    
-    static private RequestPropertiesCallback mRequestPropertiesCallback;
-    
-    private static UrlImageCache mLiveCache = UrlImageCache.getInstance();
-    
-    private static UrlLruCache mDeadCache;
-    
-    private static HashSet<BitmapDrawable> mAllCache = new HashSet<BitmapDrawable>();
-    
-    private static UrlDownloader mDownloader = mDefaultDownloader;
-    
-    private static Hashtable<ImageView, String> mPendingViews = new Hashtable<ImageView, String>();
-    
-    private static Hashtable<String, ArrayList<ImageView>> mPendingDownloads = new Hashtable<String, ArrayList<ImageView>>();
-    
-    private static void cleanup(final Context context) {
-        if (mHasCleaned) {
-            return;
-        }
-        mHasCleaned = true;
-        try {
-            // purge any *.urlimage files over a week old
-            final String[] files = context.getFilesDir().list();
-            if (files == null) {
-                return;
-            }
-            for (final String file : files) {
-                if (!file.endsWith(".urlimage")) {
-                    continue;
-                }
-                
-                final File f = new File(context.getFilesDir().getAbsolutePath()
-                        + '/' + file);
-                if (System.currentTimeMillis() > f.lastModified()
-                        + CACHE_DURATION_ONE_WEEK) {
-                    f.delete();
-                }
-            }
-        } catch (final Exception e) {
-            e.printStackTrace();
-        }
-    }
-    
-    public static int copyStream(final InputStream input,
-            final OutputStream output) throws IOException
+
+    public static int copyStream(InputStream input, OutputStream output) throws IOException
     {
-        final byte[] stuff = new byte[1024];
+        byte[] stuff = new byte[1024];
         int read = 0;
         int total = 0;
         while ((read = input.read(stuff)) != -1)
@@ -323,52 +53,24 @@ public final class UrlImageViewHelper {
         }
         return total;
     }
-    
-    private static void executeTask(final AsyncTask<Void, Void, Void> task) {
-        if (Build.VERSION.SDK_INT < Constants.HONEYCOMB) {
-            task.execute();
-        } else {
-            executeTaskHoneycomb(task);
-        }
+
+    static Resources mResources;
+    static DisplayMetrics mMetrics;
+    private static void prepareResources(Context context) {
+        if (mMetrics != null)
+            return;
+        mMetrics = new DisplayMetrics();
+        Activity act = (Activity)context;
+        act.getWindowManager().getDefaultDisplay().getMetrics(mMetrics);
+        AssetManager mgr = context.getAssets();
+        mResources = new Resources(mgr, mMetrics, context.getResources().getConfiguration());
     }
-    
-    @TargetApi(Constants.HONEYCOMB)
-    private static void executeTaskHoneycomb(
-            final AsyncTask<Void, Void, Void> task) {
-        task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
-    }
-    
-    public static UrlDownloader getDefaultDownloader() {
-        return mDownloader;
-    }
-    
-    public static String getFilenameForUrl(final String url) {
-        return "" + url.hashCode() + ".urlimage";
-    }
-    
-    private static int getHeapSize(final Context context) {
-        return ((ActivityManager) context
-                .getSystemService(Context.ACTIVITY_SERVICE)).getMemoryClass() * 1024 * 1024;
-    }
-    
-    static public RequestPropertiesCallback getRequestPropertiesCallback() {
-        return mRequestPropertiesCallback;
-    }
-    
-    private static boolean isNullOrEmpty(final CharSequence s) {
-        return (s == null || s.equals("") || s.equals("null") || s
-                .equals("NULL"));
-    }
-    
-    private static Drawable loadDrawableFromStream(final Context context,
-            final String url, final String filename, final int targetWidth,
-            final int targetHeight) {
+
+    private static Drawable loadDrawableFromStream(Context context, String url, String filename, int targetWidth, int targetHeight) {
         prepareResources(context);
         
-        if (Constants.LOG_ENABLED) {
-            Log.v(Constants.LOGTAG, "Target Width: " + targetWidth);
-            Log.v(Constants.LOGTAG, "Target Height: " + targetHeight);
-        }
+//        Log.v(Constants.LOGTAG,targetWidth);
+//        Log.v(Constants.LOGTAG,targetHeight);
         try {
             BitmapFactory.Options o = new BitmapFactory.Options();
             o.inJustDecodeBounds = true;
@@ -377,279 +79,418 @@ public final class UrlImageViewHelper {
             stream.close();
             stream = new FileInputStream(filename);
             int scale = 0;
-            while ((o.outWidth >> scale) > targetWidth
-                    || (o.outHeight >> scale) > targetHeight) {
-                Log.v(Constants.LOGTAG, "downsampling");
+            while ((o.outWidth >> scale) > targetWidth || (o.outHeight >> scale) > targetHeight) {
+                Log.v(Constants.LOGTAG,"downsampling");
                 scale++;
             }
             o = new Options();
             o.inSampleSize = 1 << scale;
             final Bitmap bitmap = BitmapFactory.decodeStream(stream, null, o);
-            if (Constants.LOG_ENABLED) {
-                Log.i(Constants.LOGTAG, String.format("Loaded bitmap (%dx%d).",
-                        bitmap.getWidth(), bitmap.getHeight()));
-            }
-            final BitmapDrawable bd = new BitmapDrawable(mResources, bitmap);
+            if (Constants.LOG_ENABLED)
+                Log.i(Constants.LOGTAG, String.format("Loaded bitmap (%dx%d).", bitmap.getWidth(), bitmap.getHeight()));
+            BitmapDrawable bd = new BitmapDrawable(mResources, bitmap);
             return new ZombieDrawable(url, bd);
-        } catch (final IOException e) {
+        }
+        catch (IOException e) {
             return null;
         }
     }
-    
-    public static void loadUrlDrawable(final Context context, final String url) {
-        setUrlDrawable(context, null, url, null, CACHE_DURATION_THREE_DAYS,
-                null);
+
+    public static final int CACHE_DURATION_INFINITE = Integer.MAX_VALUE;
+    public static final int CACHE_DURATION_ONE_DAY = 1000 * 60 * 60 * 24;
+    public static final int CACHE_DURATION_TWO_DAYS = CACHE_DURATION_ONE_DAY * 2;
+    public static final int CACHE_DURATION_THREE_DAYS = CACHE_DURATION_ONE_DAY * 3;
+    public static final int CACHE_DURATION_FOUR_DAYS = CACHE_DURATION_ONE_DAY * 4;
+    public static final int CACHE_DURATION_FIVE_DAYS = CACHE_DURATION_ONE_DAY * 5;
+    public static final int CACHE_DURATION_SIX_DAYS = CACHE_DURATION_ONE_DAY * 6;
+    public static final int CACHE_DURATION_ONE_WEEK = CACHE_DURATION_ONE_DAY * 7;
+
+    public static void setUrlDrawable(final ImageView imageView, final String url, int defaultResource) {
+        setUrlDrawable(imageView.getContext(), imageView, url, defaultResource, CACHE_DURATION_THREE_DAYS);
     }
-    
-    public static void loadUrlDrawable(final Context context, final String url,
-            final long cacheDurationMs) {
+
+    public static void setUrlDrawable(final ImageView imageView, final String url) {
+        setUrlDrawable(imageView.getContext(), imageView, url, null, CACHE_DURATION_THREE_DAYS, null);
+    }
+
+    public static void loadUrlDrawable(final Context context, final String url) {
+        setUrlDrawable(context, null, url, null, CACHE_DURATION_THREE_DAYS, null);
+    }
+
+    public static void setUrlDrawable(final ImageView imageView, final String url, Drawable defaultDrawable) {
+        setUrlDrawable(imageView.getContext(), imageView, url, defaultDrawable, CACHE_DURATION_THREE_DAYS, null);
+    }
+
+    public static void setUrlDrawable(final ImageView imageView, final String url, int defaultResource, long cacheDurationMs) {
+        setUrlDrawable(imageView.getContext(), imageView, url, defaultResource, cacheDurationMs);
+    }
+
+    public static void loadUrlDrawable(final Context context, final String url, long cacheDurationMs) {
         setUrlDrawable(context, null, url, null, cacheDurationMs, null);
     }
-    
-    public static void loadUrlDrawable(final Context context, final String url,
-            final long cacheDurationMs, final UrlImageViewCallback callback) {
+
+    public static void setUrlDrawable(final ImageView imageView, final String url, Drawable defaultDrawable, long cacheDurationMs) {
+        setUrlDrawable(imageView.getContext(), imageView, url, defaultDrawable, cacheDurationMs, null);
+    }
+
+    private static void setUrlDrawable(final Context context, final ImageView imageView, final String url, int defaultResource, long cacheDurationMs) {
+        Drawable d = null;
+        if (defaultResource != 0)
+            d = imageView.getResources().getDrawable(defaultResource);
+        setUrlDrawable(context, imageView, url, d, cacheDurationMs, null);
+    }
+
+    public static void setUrlDrawable(final ImageView imageView, final String url, int defaultResource, UrlImageViewCallback callback) {
+        setUrlDrawable(imageView.getContext(), imageView, url, defaultResource, CACHE_DURATION_THREE_DAYS, callback);
+    }
+
+    public static void setUrlDrawable(final ImageView imageView, final String url, UrlImageViewCallback callback) {
+        setUrlDrawable(imageView.getContext(), imageView, url, null, CACHE_DURATION_THREE_DAYS, callback);
+    }
+
+    public static void loadUrlDrawable(final Context context, final String url, UrlImageViewCallback callback) {
+        setUrlDrawable(context, null, url, null, CACHE_DURATION_THREE_DAYS, callback);
+    }
+
+    public static void setUrlDrawable(final ImageView imageView, final String url, Drawable defaultDrawable, UrlImageViewCallback callback) {
+        setUrlDrawable(imageView.getContext(), imageView, url, defaultDrawable, CACHE_DURATION_THREE_DAYS, callback);
+    }
+
+    public static void setUrlDrawable(final ImageView imageView, final String url, int defaultResource, long cacheDurationMs, UrlImageViewCallback callback) {
+        setUrlDrawable(imageView.getContext(), imageView, url, defaultResource, cacheDurationMs, callback);
+    }
+
+    public static void loadUrlDrawable(final Context context, final String url, long cacheDurationMs, UrlImageViewCallback callback) {
         setUrlDrawable(context, null, url, null, cacheDurationMs, callback);
     }
-    
-    public static void loadUrlDrawable(final Context context, final String url,
-            final UrlImageViewCallback callback) {
-        setUrlDrawable(context, null, url, null, CACHE_DURATION_THREE_DAYS,
-                callback);
+
+    public static void setUrlDrawable(final ImageView imageView, final String url, Drawable defaultDrawable, long cacheDurationMs, UrlImageViewCallback callback) {
+        setUrlDrawable(imageView.getContext(), imageView, url, defaultDrawable, cacheDurationMs, callback);
     }
-    
-    private static void prepareResources(final Context context) {
-        if (mMetrics != null) {
+
+    private static void setUrlDrawable(final Context context, final ImageView imageView, final String url, int defaultResource, long cacheDurationMs, UrlImageViewCallback callback) {
+        Drawable d = null;
+        if (defaultResource != 0)
+            d = imageView.getResources().getDrawable(defaultResource);
+        setUrlDrawable(context, imageView, url, d, cacheDurationMs, callback);
+    }
+
+    private static boolean isNullOrEmpty(CharSequence s) {
+        return (s == null || s.equals("") || s.equals("null") || s.equals("NULL"));
+    }
+
+    private static boolean mHasCleaned = false;
+
+    public static String getFilenameForUrl(String url) {
+        return "" + url.hashCode() + ".urlimage";
+    }
+
+    private static void cleanup(Context context) {
+        if (mHasCleaned)
             return;
+        mHasCleaned = true;
+        try {
+            // purge any *.urlimage files over a week old
+            String[] files = context.getFilesDir().list();
+            if (files == null)
+                return;
+            for (String file : files) {
+                if (!file.endsWith(".urlimage"))
+                    continue;
+
+                File f = new File(context.getFilesDir().getAbsolutePath() + '/' + file);
+                if (System.currentTimeMillis() > f.lastModified() + CACHE_DURATION_ONE_WEEK)
+                    f.delete();
+            }
         }
-        mMetrics = new DisplayMetrics();
-        final Activity act = (Activity) context;
-        act.getWindowManager().getDefaultDisplay().getMetrics(mMetrics);
-        final AssetManager mgr = context.getAssets();
-        mResources = new Resources(mgr, mMetrics, context.getResources()
-                .getConfiguration());
+        catch (Exception e) {
+            e.printStackTrace();
+        }
     }
-    
-    public static void setRequestPropertiesCallback(
-            final RequestPropertiesCallback callback) {
-        mRequestPropertiesCallback = callback;
-    }
-    
-    private static void setUrlDrawable(final Context context,
-            final ImageView imageView, final String url,
-            final Drawable defaultDrawable, final long cacheDurationMs,
-            final UrlImageViewCallback callback) {
+
+    private static void setUrlDrawable(final Context context, final ImageView imageView, final String url, final Drawable defaultDrawable, long cacheDurationMs, final UrlImageViewCallback callback) {
         cleanup(context);
         // disassociate this ImageView from any pending downloads
         if (isNullOrEmpty(url)) {
-            if (imageView != null) {
+            if (imageView != null)
                 imageView.setImageDrawable(defaultDrawable);
-            }
+            return;
+        }
+
+        WindowManager wm = (WindowManager)context.getSystemService(Context.WINDOW_SERVICE);
+        Display display = wm.getDefaultDisplay();
+        final int tw = display.getWidth();
+        final int th = display.getHeight();
+
+        if (mDeadCache == null)
+            mDeadCache = new UrlLruCache(getHeapSize(context) / 8);
+        Drawable drawable;
+        BitmapDrawable zd = mDeadCache.remove(url);
+        if (zd != null) {
+            // this drawable was resurrected, it should not be in the live cache
+            if (Constants.LOG_ENABLED)
+                Log.i(Constants.LOGTAG, "zombie load");
+            Assert.assertTrue(!mAllCache.contains(zd));
+            drawable = new ZombieDrawable(url, zd);
+        }
+        else {
+            drawable = mLiveCache.get(url);
+        }
+
+        if (drawable != null) {
+            if (Constants.LOG_ENABLED)
+                Log.i(Constants.LOGTAG, "Cache hit on: " + url);
+            if (imageView != null)
+                imageView.setImageDrawable(drawable);
+            if (callback != null)
+                callback.onLoaded(imageView, drawable, url, true);
             return;
         }
         
-        final int tw = mMetrics.widthPixels;
-        final int th = mMetrics.heightPixels;
-        
-        if (mDeadCache == null) {
-            mDeadCache = new UrlLruCache(getHeapSize(context) / 8);
+        // oh noes, at this point we definitely do not have the file available in memory
+        // let's prepare for an asynchronous load of the image.
+
+        final String filename = context.getFileStreamPath(getFilenameForUrl(url)).getAbsolutePath();
+
+        // null it while it is downloading
+        if (imageView != null)
+            imageView.setImageDrawable(defaultDrawable);
+
+        // since listviews reuse their views, we need to 
+        // take note of which url this view is waiting for.
+        // This may change rapidly as the list scrolls or is filtered, etc.
+        if (Constants.LOG_ENABLED)
+            Log.i(Constants.LOGTAG, "Waiting for " + url);
+        if (imageView != null)
+            mPendingViews.put(imageView, url);
+
+        ArrayList<ImageView> currentDownload = mPendingDownloads.get(url);
+        if (currentDownload != null) {
+            // Also, multiple vies may be waiting for this url.
+            // So, let's maintain a list of these views.
+            // When the url is downloaded, it sets the imagedrawable for
+            // every view in the list. It needs to also validate that
+            // the imageview is still waiting for this url.
+            if (imageView != null)
+                currentDownload.add(imageView);
+            return;
         }
-        Drawable drawable;
-        final BitmapDrawable zombieDrawable = mDeadCache.remove(url);
-        if (zombieDrawable != null) {
-            // this drawable was resurrected, it should not be in the live cache
-            if (Constants.LOG_ENABLED) {
-                Log.i(Constants.LOGTAG, "zombie load");
-            }
-            Assert.assertTrue(!mAllCache.contains(zombieDrawable));
-            drawable = new ZombieDrawable(url, zombieDrawable);
-        } else {
-            drawable = mLiveCache.get(url);
-        }
-        
-        if (drawable != null) {
-            if (Constants.LOG_ENABLED) {
-                Log.i(Constants.LOGTAG, "Cache hit on: " + url);
-            }
-            if (imageView != null) {
-                imageView.setImageDrawable(drawable);
-            }
-            if (callback != null) {
-                callback.onLoaded(imageView, drawable, url, true);
-            }
-        } else {
-            
-            // oh noes, at this point we definitely do not have the file
-            // available
-            // in memory let's prepare for an asynchronous load of the image.
-            final String filename = context.getFileStreamPath(
-                    getFilenameForUrl(url)).getAbsolutePath();
-            
-            // null it while it is downloading
-            if (imageView != null) {
-                imageView.setImageDrawable(defaultDrawable);
-            }
-            
-            // since listviews reuse their views, we need to
-            // take note of which url this view is waiting for.
-            // This may change rapidly as the list scrolls or is filtered, etc.
-            if (Constants.LOG_ENABLED) {
-                Log.i(Constants.LOGTAG, "Waiting for " + url);
-            }
-            if (imageView != null) {
-                mPendingViews.put(imageView, url);
-            }
-            
-            final ArrayList<ImageView> currentDownload = mPendingDownloads
-                    .get(url);
-            if (currentDownload != null) {
-                // Also, multiple views may be waiting for this url.
-                // So, let's maintain a list of these views.
-                // When the url is downloaded, it sets the imagedrawable for
-                // every view in the list. It needs to also validate that
-                // the imageview is still waiting for this url.
-                if (imageView != null) {
-                    currentDownload.add(imageView);
+
+        final ArrayList<ImageView> downloads = new ArrayList<ImageView>();
+        if (imageView != null)
+            downloads.add(imageView);
+        mPendingDownloads.put(url, downloads);
+
+        final int targetWidth = tw <= 0 ? Integer.MAX_VALUE : tw;
+        final int targetHeight = th <= 0 ? Integer.MAX_VALUE : th;
+        final Loader loader = new Loader() {
+            @Override
+            public void run() {
+                try {
+                    result = loadDrawableFromStream(context, url, filename, targetWidth, targetHeight);
                 }
-            } else {
-                final ArrayList<ImageView> downloads = new ArrayList<ImageView>();
-                if (imageView != null) {
-                    downloads.add(imageView);
+                catch (Exception ex) {
                 }
-                mPendingDownloads.put(url, downloads);
-                
-                final int targetWidth = tw <= 0 ? Integer.MAX_VALUE : tw;
-                final int targetHeight = th <= 0 ? Integer.MAX_VALUE : th;
-                final Loader loader = new DefaultLoader(context, filename,
-                        targetWidth, targetHeight, url);
-                
-                final Runnable completion = new OnImageLoadRunnable(url,
-                        loader, downloads, callback, defaultDrawable);
-                
-                final File file = new File(filename);
-                if (file.exists()) {
-                    try {
-                        if (cacheDurationMs == CACHE_DURATION_INFINITE
-                                || System.currentTimeMillis() < file
-                                        .lastModified() + cacheDurationMs) {
-                            if (Constants.LOG_ENABLED) {
-                                Log.i(Constants.LOGTAG, "File Cache hit on: "
-                                        + url + ". "
-                                        + (System.currentTimeMillis() - file
-                                                .lastModified()) + "ms old.");
-                            }
-                            
-                            executeTask(new AsyncLoadFileTask(loader,
-                                    completion));
-                        } else {
-                            if (Constants.LOG_ENABLED) {
-                                Log.i(Constants.LOGTAG,
-                                        "File cache has expired. Refreshing.");
-                            }
-                        }
-                    } catch (final Exception ex) {
-                        if (Constants.LOG_ENABLED) {
-                            Log.e(Constants.LOGTAG, "Exception", ex);
-                        }
+            }
+        };
+
+        final Runnable completion = new Runnable() {
+            @Override
+            public void run() {
+                Assert.assertEquals(Looper.myLooper(), Looper.getMainLooper());
+                Drawable usableResult = loader.result;
+                if (usableResult == null)
+                    usableResult = defaultDrawable;
+                mPendingDownloads.remove(url);
+                mLiveCache.put(url, usableResult);
+                for (ImageView iv: downloads) {
+                    // validate the url it is waiting for
+                    String pendingUrl = mPendingViews.get(iv);
+                    if (!url.equals(pendingUrl)) {
+                        if (Constants.LOG_ENABLED)
+                            Log.i(Constants.LOGTAG, "Ignoring out of date request to update view for " + url);
+                        continue;
+                    }
+                    mPendingViews.remove(iv);
+                    if (usableResult != null) {
+                        //                        System.out.println(String.format("imageView: %dx%d, %dx%d", imageView.getMeasuredWidth(), imageView.getMeasuredHeight(), imageView.getWidth(), imageView.getHeight()));
+                        iv.setImageDrawable(usableResult);
+//                        System.out.println(String.format("imageView: %dx%d, %dx%d", imageView.getMeasuredWidth(), imageView.getMeasuredHeight(), imageView.getWidth(), imageView.getHeight()));
+                        if (callback != null)
+                            callback.onLoaded(iv, loader.result, url, false);
                     }
                 }
-                mDownloader.download(context, url, filename, loader,
-                        completion);
+            }
+        };
+        
+
+        File file = new File(filename);
+        if (file.exists()) {
+            try {
+                if (cacheDurationMs == CACHE_DURATION_INFINITE || System.currentTimeMillis() < file.lastModified() + cacheDurationMs) {
+                    if (Constants.LOG_ENABLED)
+                        Log.i(Constants.LOGTAG, "File Cache hit on: " + url + ". " + (System.currentTimeMillis() - file.lastModified()) + "ms old.");
+                    
+                    AsyncTask<Void, Void, Void> fileloader = new AsyncTask<Void, Void, Void>() {
+                        protected Void doInBackground(Void[] params) {
+                            loader.run();
+                            return null;
+                        }
+                        protected void onPostExecute(Void result) {
+                            completion.run();
+                        }
+                    };
+                    executeTask(fileloader);
+                    return;
+                }
+                else {
+                    if (Constants.LOG_ENABLED)
+                        Log.i(Constants.LOGTAG, "File cache has expired. Refreshing.");
+                }
+            }
+            catch (Exception ex) {
             }
         }
+
+        mDownloader.download(context, url, filename, loader, completion);
     }
-    
-    private static void setUrlDrawable(final Context context,
-            final ImageView imageView, final String url,
-            final int defaultResource, final long cacheDurationMs) {
-        Drawable d = null;
-        if (defaultResource != 0) {
-            d = imageView.getResources().getDrawable(defaultResource);
+
+    private static abstract class Loader implements Runnable {
+        public Drawable result;
+    }
+
+    public static interface UrlDownloader {
+        public void download(Context context, String url, String filename, Runnable loader, Runnable completion);
+    }
+
+    private static UrlDownloader mDefaultDownloader = new UrlDownloader() {
+        @Override
+        public void download(final Context context, final String url, final String filename, final Runnable loader, final Runnable completion) {
+            AsyncTask<Void, Void, Void> downloader = new AsyncTask<Void, Void, Void>() {
+                @Override
+                protected Void doInBackground(Void... params) {
+                    try {
+                        InputStream is = null;
+                        if (url.startsWith(ContactsContract.Contacts.CONTENT_URI.toString())) {
+                            ContentResolver cr = context.getContentResolver();
+                            is = ContactsContract.Contacts.openContactPhotoInputStream(cr, Uri.parse(url));
+                        }
+                        else {
+                            URL u = new URL(url);
+                            HttpURLConnection urlConnection = (HttpURLConnection)u.openConnection();
+                            
+                            if (mRequestPropertiesCallback != null) {
+                                ArrayList<NameValuePair> props = mRequestPropertiesCallback.getHeadersForRequest(context, url);
+                                if (props != null) {
+                                    for (NameValuePair pair: props) {
+                                        urlConnection.addRequestProperty(pair.getName(), pair.getValue());
+                                    }
+                                }
+                            }
+
+                            if (urlConnection.getResponseCode() != HttpURLConnection.HTTP_OK)
+                                return null;
+                            is = urlConnection.getInputStream();
+                        }
+                        
+                        if (is != null) {
+                            FileOutputStream fos = new FileOutputStream(filename);
+                            copyStream(is, fos);
+                            fos.close();
+                            is.close();
+                        }
+                        loader.run();
+                        return null;
+                    }
+                    catch (Throwable e) {
+                        e.printStackTrace();
+                        return null;
+                    }
+                }
+
+                protected void onPostExecute(Void result) {
+                    completion.run();
+                }
+            };
+
+            executeTask(downloader);
         }
-        setUrlDrawable(context, imageView, url, d, cacheDurationMs, null);
+    };
+    
+    static public interface RequestPropertiesCallback {
+        public ArrayList<NameValuePair> getHeadersForRequest(Context context, String url);
     }
     
-    private static void setUrlDrawable(final Context context,
-            final ImageView imageView, final String url,
-            final int defaultResource, final long cacheDurationMs,
-            final UrlImageViewCallback callback) {
-        Drawable d = null;
-        if (defaultResource != 0) {
-            d = imageView.getResources().getDrawable(defaultResource);
-        }
-        setUrlDrawable(context, imageView, url, d, cacheDurationMs, callback);
+    static private RequestPropertiesCallback mRequestPropertiesCallback;
+    static public RequestPropertiesCallback getRequestPropertiesCallback() {
+        return mRequestPropertiesCallback;
     }
     
-    public static void setUrlDrawable(final ImageView imageView,
-            final String url) {
-        setUrlDrawable(imageView.getContext(), imageView, url, null,
-                CACHE_DURATION_THREE_DAYS, null);
+    static public void setRequestPropertiesCallback(RequestPropertiesCallback callback) {
+        mRequestPropertiesCallback = callback;
     }
     
-    public static void setUrlDrawable(final ImageView imageView,
-            final String url, final Drawable defaultDrawable) {
-        setUrlDrawable(imageView.getContext(), imageView, url, defaultDrawable,
-                CACHE_DURATION_THREE_DAYS, null);
-    }
     
-    public static void setUrlDrawable(final ImageView imageView,
-            final String url, final Drawable defaultDrawable,
-            final long cacheDurationMs) {
-        setUrlDrawable(imageView.getContext(), imageView, url, defaultDrawable,
-                cacheDurationMs, null);
+    public static void useDownloader(UrlDownloader downloader) {
+        mDownloader = downloader;
     }
-    
-    public static void setUrlDrawable(final ImageView imageView,
-            final String url, final Drawable defaultDrawable,
-            final long cacheDurationMs, final UrlImageViewCallback callback) {
-        setUrlDrawable(imageView.getContext(), imageView, url, defaultDrawable,
-                cacheDurationMs, callback);
-    }
-    
-    public static void setUrlDrawable(final ImageView imageView,
-            final String url, final Drawable defaultDrawable,
-            final UrlImageViewCallback callback) {
-        setUrlDrawable(imageView.getContext(), imageView, url, defaultDrawable,
-                CACHE_DURATION_THREE_DAYS, callback);
-    }
-    
-    public static void setUrlDrawable(final ImageView imageView,
-            final String url, final int defaultResource) {
-        setUrlDrawable(imageView.getContext(), imageView, url, defaultResource,
-                CACHE_DURATION_THREE_DAYS);
-    }
-    
-    public static void setUrlDrawable(final ImageView imageView,
-            final String url, final int defaultResource,
-            final long cacheDurationMs) {
-        setUrlDrawable(imageView.getContext(), imageView, url, defaultResource,
-                cacheDurationMs);
-    }
-    
-    public static void setUrlDrawable(final ImageView imageView,
-            final String url, final int defaultResource,
-            final long cacheDurationMs, final UrlImageViewCallback callback) {
-        setUrlDrawable(imageView.getContext(), imageView, url, defaultResource,
-                cacheDurationMs, callback);
-    }
-    
-    public static void setUrlDrawable(final ImageView imageView,
-            final String url, final int defaultResource,
-            final UrlImageViewCallback callback) {
-        setUrlDrawable(imageView.getContext(), imageView, url, defaultResource,
-                CACHE_DURATION_THREE_DAYS, callback);
-    }
-    
-    public static void setUrlDrawable(final ImageView imageView,
-            final String url, final UrlImageViewCallback callback) {
-        setUrlDrawable(imageView.getContext(), imageView, url, null,
-                CACHE_DURATION_THREE_DAYS, callback);
-    }
-    
+
     public static void useDefaultDownloader() {
         mDownloader = mDefaultDownloader;
     }
     
-    public static void useDownloader(final UrlDownloader downloader) {
-        mDownloader = downloader;
+    public static UrlDownloader getDefaultDownloader() {
+        return mDownloader;
     }
+
+    private static UrlImageCache mLiveCache = UrlImageCache.getInstance();
+
+    private static UrlLruCache mDeadCache;
+    private static HashSet<BitmapDrawable> mAllCache = new HashSet<BitmapDrawable>();
+    private static int getHeapSize(Context context) {
+        return ((ActivityManager)context.getSystemService(Context.ACTIVITY_SERVICE)).getMemoryClass() * 1024 * 1024;
+    }
+    
+    private static class ZombieDrawable extends WrapperDrawable {
+        public ZombieDrawable(String url, BitmapDrawable drawable) {
+            super(drawable);
+            mUrl = url;
+
+            mAllCache.add(drawable);
+            mDeadCache.remove(url);
+            mLiveCache.put(url, this);
+        }
+        
+        String mUrl;
+        
+        @Override
+        protected void finalize() throws Throwable {
+            super.finalize();
+
+            mDeadCache.put(mUrl, mDrawable);
+            mAllCache.remove(mDrawable);
+            mLiveCache.remove(mUrl);
+            if (Constants.LOG_ENABLED)
+                Log.i(Constants.LOGTAG, "Zombie GC event");
+            System.gc();
+        }
+    }
+
+
+    private static UrlDownloader mDownloader = mDefaultDownloader;
+
+    private static void executeTask(AsyncTask<Void, Void, Void> task) {
+        if (Build.VERSION.SDK_INT < Constants.HONEYCOMB)
+            task.execute();
+        else
+            executeTaskHoneycomb(task);
+    }
+    
+    @TargetApi(Constants.HONEYCOMB)
+    private static void executeTaskHoneycomb(AsyncTask<Void, Void, Void> task) {
+        task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+    }
+
+    private static Hashtable<ImageView, String> mPendingViews = new Hashtable<ImageView, String>();
+    private static Hashtable<String, ArrayList<ImageView>> mPendingDownloads = new Hashtable<String, ArrayList<ImageView>>();
 }

--- a/UrlImageViewHelper/src/com/koushikdutta/urlimageviewhelper/UrlImageViewHelper.java
+++ b/UrlImageViewHelper/src/com/koushikdutta/urlimageviewhelper/UrlImageViewHelper.java
@@ -35,15 +35,285 @@ import android.os.Looper;
 import android.provider.ContactsContract;
 import android.util.DisplayMetrics;
 import android.util.Log;
-import android.view.Display;
-import android.view.WindowManager;
 import android.widget.ImageView;
 
 public final class UrlImageViewHelper {
-
-    public static int copyStream(InputStream input, OutputStream output) throws IOException
+    
+    private static final class AsyncLoadFileTask extends
+            AsyncTask<Void, Void, Void> {
+        private final Loader loader;
+        private final Runnable completion;
+        
+        private AsyncLoadFileTask(final Loader loader, final Runnable completion) {
+            this.loader = loader;
+            this.completion = completion;
+        }
+        
+        @Override
+        protected Void doInBackground(final Void... params) {
+            loader.run();
+            return null;
+        }
+        
+        @Override
+        protected void onPostExecute(final Void result) {
+            completion.run();
+        }
+    }
+    
+    private static final class DefaultLoader extends Loader {
+        private final Context context;
+        private final String filename;
+        private final int targetWidth;
+        private final int targetHeight;
+        private final String url;
+        
+        private DefaultLoader(final Context context, final String filename,
+                final int targetWidth, final int targetHeight, final String url) {
+            this.context = context;
+            this.filename = filename;
+            this.targetWidth = targetWidth;
+            this.targetHeight = targetHeight;
+            this.url = url;
+        }
+        
+        @Override
+        public void run() {
+            try {
+                result = loadDrawableFromStream(context, url, filename,
+                        targetWidth, targetHeight);
+            } catch (final Exception ex) {
+            }
+        }
+    }
+    
+    private static abstract class Loader implements Runnable {
+        public Drawable result;
+    }
+    
+    private static final class OnImageLoadRunnable implements Runnable {
+        private final String url;
+        private final Loader loader;
+        private final ArrayList<ImageView> downloads;
+        private final UrlImageViewCallback callback;
+        private final Drawable defaultDrawable;
+        
+        private OnImageLoadRunnable(final String url, final Loader loader,
+                final ArrayList<ImageView> downloads,
+                final UrlImageViewCallback callback,
+                final Drawable defaultDrawable) {
+            this.url = url;
+            this.loader = loader;
+            this.downloads = downloads;
+            this.callback = callback;
+            this.defaultDrawable = defaultDrawable;
+        }
+        
+        @Override
+        public void run() {
+            Assert.assertEquals(Looper.myLooper(), Looper
+                    .getMainLooper());
+            Drawable usableResult = loader.result;
+            if (usableResult == null) {
+                usableResult = defaultDrawable;
+            }
+            mPendingDownloads.remove(url);
+            mLiveCache.put(url, usableResult);
+            for (final ImageView iv : downloads) {
+                // validate the url it is waiting for
+                final String pendingUrl = mPendingViews.get(iv);
+                if (!url.equals(pendingUrl)) {
+                    if (Constants.LOG_ENABLED) {
+                        Log.i(Constants.LOGTAG,
+                                "Ignoring out of date request to update view for "
+                                        + url);
+                    }
+                    continue;
+                }
+                mPendingViews.remove(iv);
+                if (usableResult != null) {
+                    // System.out.println(String.format("imageView: %dx%d, %dx%d",
+                    // imageView.getMeasuredWidth(),
+                    // imageView.getMeasuredHeight(),
+                    // imageView.getWidth(),
+                    // imageView.getHeight()));
+                    iv.setImageDrawable(usableResult);
+                    // System.out.println(String.format("imageView: %dx%d, %dx%d",
+                    // imageView.getMeasuredWidth(),
+                    // imageView.getMeasuredHeight(),
+                    // imageView.getWidth(),
+                    // imageView.getHeight()));
+                    if (callback != null) {
+                        callback.onLoaded(iv, loader.result, url, false);
+                    }
+                }
+            }
+        }
+    }
+    
+    static public interface RequestPropertiesCallback {
+        public ArrayList<NameValuePair> getHeadersForRequest(Context context,
+                String url);
+    }
+    
+    public static interface UrlDownloader {
+        public void download(Context context, String url, String filename,
+                Runnable loader, Runnable completion);
+    }
+    
+    private static class ZombieDrawable extends WrapperDrawable {
+        String mUrl;
+        
+        public ZombieDrawable(final String url, final BitmapDrawable drawable) {
+            super(drawable);
+            mUrl = url;
+            
+            mAllCache.add(drawable);
+            mDeadCache.remove(url);
+            mLiveCache.put(url, this);
+        }
+        
+        @Override
+        protected void finalize() throws Throwable {
+            super.finalize();
+            
+            mDeadCache.put(mUrl, mDrawable);
+            mAllCache.remove(mDrawable);
+            mLiveCache.remove(mUrl);
+            if (Constants.LOG_ENABLED) {
+                Log.i(Constants.LOGTAG, "Zombie GC event");
+            }
+            System.gc();
+        }
+    }
+    
+    static Resources mResources;
+    
+    static DisplayMetrics mMetrics;
+    public static final int CACHE_DURATION_INFINITE = Integer.MAX_VALUE;
+    public static final int CACHE_DURATION_ONE_DAY = 1000 * 60 * 60 * 24;
+    public static final int CACHE_DURATION_TWO_DAYS = CACHE_DURATION_ONE_DAY * 2;
+    public static final int CACHE_DURATION_THREE_DAYS = CACHE_DURATION_ONE_DAY * 3;
+    public static final int CACHE_DURATION_FOUR_DAYS = CACHE_DURATION_ONE_DAY * 4;
+    public static final int CACHE_DURATION_FIVE_DAYS = CACHE_DURATION_ONE_DAY * 5;
+    public static final int CACHE_DURATION_SIX_DAYS = CACHE_DURATION_ONE_DAY * 6;
+    
+    public static final int CACHE_DURATION_ONE_WEEK = CACHE_DURATION_ONE_DAY * 7;
+    
+    private static boolean mHasCleaned = false;
+    
+    private static UrlDownloader mDefaultDownloader = new UrlDownloader() {
+        @Override
+        public void download(final Context context, final String url,
+                final String filename, final Runnable loader,
+                final Runnable completion) {
+            final AsyncTask<Void, Void, Void> downloader = new AsyncTask<Void, Void, Void>() {
+                @Override
+                protected Void doInBackground(final Void... params) {
+                    try {
+                        InputStream is = null;
+                        if (url.startsWith(ContactsContract.Contacts.CONTENT_URI
+                                .toString())) {
+                            final ContentResolver cr = context
+                                    .getContentResolver();
+                            is = ContactsContract.Contacts
+                                    .openContactPhotoInputStream(cr, Uri
+                                            .parse(url));
+                        }
+                        else {
+                            final URL u = new URL(url);
+                            final HttpURLConnection urlConnection = (HttpURLConnection) u
+                                    .openConnection();
+                            
+                            if (mRequestPropertiesCallback != null) {
+                                final ArrayList<NameValuePair> props = mRequestPropertiesCallback
+                                        .getHeadersForRequest(context, url);
+                                if (props != null) {
+                                    for (final NameValuePair pair : props) {
+                                        urlConnection.addRequestProperty(pair
+                                                .getName(), pair.getValue());
+                                    }
+                                }
+                            }
+                            
+                            if (urlConnection.getResponseCode() != HttpURLConnection.HTTP_OK) {
+                                return null;
+                            }
+                            is = urlConnection.getInputStream();
+                        }
+                        
+                        if (is != null) {
+                            final FileOutputStream fos = new FileOutputStream(
+                                    filename);
+                            copyStream(is, fos);
+                            fos.close();
+                            is.close();
+                        }
+                        loader.run();
+                        return null;
+                    }
+                    catch (final Throwable e) {
+                        e.printStackTrace();
+                        return null;
+                    }
+                }
+                
+                @Override
+                protected void onPostExecute(final Void result) {
+                    completion.run();
+                }
+            };
+            
+            executeTask(downloader);
+        }
+    };
+    
+    static private RequestPropertiesCallback mRequestPropertiesCallback;
+    
+    private static UrlImageCache mLiveCache = UrlImageCache.getInstance();
+    
+    private static UrlLruCache mDeadCache;
+    
+    private static HashSet<BitmapDrawable> mAllCache = new HashSet<BitmapDrawable>();
+    
+    private static UrlDownloader mDownloader = mDefaultDownloader;
+    
+    private static Hashtable<ImageView, String> mPendingViews = new Hashtable<ImageView, String>();
+    
+    private static Hashtable<String, ArrayList<ImageView>> mPendingDownloads = new Hashtable<String, ArrayList<ImageView>>();
+    
+    private static void cleanup(final Context context) {
+        if (mHasCleaned) {
+            return;
+        }
+        mHasCleaned = true;
+        try {
+            // purge any *.urlimage files over a week old
+            final String[] files = context.getFilesDir().list();
+            if (files == null) {
+                return;
+            }
+            for (final String file : files) {
+                if (!file.endsWith(".urlimage")) {
+                    continue;
+                }
+                
+                final File f = new File(context.getFilesDir().getAbsolutePath()
+                        + '/' + file);
+                if (System.currentTimeMillis() > f.lastModified()
+                        + CACHE_DURATION_ONE_WEEK) {
+                    f.delete();
+                }
+            }
+        } catch (final Exception e) {
+            e.printStackTrace();
+        }
+    }
+    
+    public static int copyStream(final InputStream input,
+            final OutputStream output) throws IOException
     {
-        byte[] stuff = new byte[1024];
+        final byte[] stuff = new byte[1024];
         int read = 0;
         int total = 0;
         while ((read = input.read(stuff)) != -1)
@@ -53,24 +323,52 @@ public final class UrlImageViewHelper {
         }
         return total;
     }
-
-    static Resources mResources;
-    static DisplayMetrics mMetrics;
-    private static void prepareResources(Context context) {
-        if (mMetrics != null)
-            return;
-        mMetrics = new DisplayMetrics();
-        Activity act = (Activity)context;
-        act.getWindowManager().getDefaultDisplay().getMetrics(mMetrics);
-        AssetManager mgr = context.getAssets();
-        mResources = new Resources(mgr, mMetrics, context.getResources().getConfiguration());
+    
+    private static void executeTask(final AsyncTask<Void, Void, Void> task) {
+        if (Build.VERSION.SDK_INT < Constants.HONEYCOMB) {
+            task.execute();
+        } else {
+            executeTaskHoneycomb(task);
+        }
     }
-
-    private static Drawable loadDrawableFromStream(Context context, String url, String filename, int targetWidth, int targetHeight) {
+    
+    @TargetApi(Constants.HONEYCOMB)
+    private static void executeTaskHoneycomb(
+            final AsyncTask<Void, Void, Void> task) {
+        task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+    }
+    
+    public static UrlDownloader getDefaultDownloader() {
+        return mDownloader;
+    }
+    
+    public static String getFilenameForUrl(final String url) {
+        return "" + url.hashCode() + ".urlimage";
+    }
+    
+    private static int getHeapSize(final Context context) {
+        return ((ActivityManager) context
+                .getSystemService(Context.ACTIVITY_SERVICE)).getMemoryClass() * 1024 * 1024;
+    }
+    
+    static public RequestPropertiesCallback getRequestPropertiesCallback() {
+        return mRequestPropertiesCallback;
+    }
+    
+    private static boolean isNullOrEmpty(final CharSequence s) {
+        return (s == null || s.equals("") || s.equals("null") || s
+                .equals("NULL"));
+    }
+    
+    private static Drawable loadDrawableFromStream(final Context context,
+            final String url, final String filename, final int targetWidth,
+            final int targetHeight) {
         prepareResources(context);
         
-//        Log.v(Constants.LOGTAG,targetWidth);
-//        Log.v(Constants.LOGTAG,targetHeight);
+        if (Constants.LOG_ENABLED) {
+            Log.v(Constants.LOGTAG, "Target Width: " + targetWidth);
+            Log.v(Constants.LOGTAG, "Target Height: " + targetHeight);
+        }
         try {
             BitmapFactory.Options o = new BitmapFactory.Options();
             o.inJustDecodeBounds = true;
@@ -79,418 +377,279 @@ public final class UrlImageViewHelper {
             stream.close();
             stream = new FileInputStream(filename);
             int scale = 0;
-            while ((o.outWidth >> scale) > targetWidth || (o.outHeight >> scale) > targetHeight) {
-                Log.v(Constants.LOGTAG,"downsampling");
+            while ((o.outWidth >> scale) > targetWidth
+                    || (o.outHeight >> scale) > targetHeight) {
+                Log.v(Constants.LOGTAG, "downsampling");
                 scale++;
             }
             o = new Options();
             o.inSampleSize = 1 << scale;
             final Bitmap bitmap = BitmapFactory.decodeStream(stream, null, o);
-            if (Constants.LOG_ENABLED)
-                Log.i(Constants.LOGTAG, String.format("Loaded bitmap (%dx%d).", bitmap.getWidth(), bitmap.getHeight()));
-            BitmapDrawable bd = new BitmapDrawable(mResources, bitmap);
+            if (Constants.LOG_ENABLED) {
+                Log.i(Constants.LOGTAG, String.format("Loaded bitmap (%dx%d).",
+                        bitmap.getWidth(), bitmap.getHeight()));
+            }
+            final BitmapDrawable bd = new BitmapDrawable(mResources, bitmap);
             return new ZombieDrawable(url, bd);
-        }
-        catch (IOException e) {
+        } catch (final IOException e) {
             return null;
         }
     }
-
-    public static final int CACHE_DURATION_INFINITE = Integer.MAX_VALUE;
-    public static final int CACHE_DURATION_ONE_DAY = 1000 * 60 * 60 * 24;
-    public static final int CACHE_DURATION_TWO_DAYS = CACHE_DURATION_ONE_DAY * 2;
-    public static final int CACHE_DURATION_THREE_DAYS = CACHE_DURATION_ONE_DAY * 3;
-    public static final int CACHE_DURATION_FOUR_DAYS = CACHE_DURATION_ONE_DAY * 4;
-    public static final int CACHE_DURATION_FIVE_DAYS = CACHE_DURATION_ONE_DAY * 5;
-    public static final int CACHE_DURATION_SIX_DAYS = CACHE_DURATION_ONE_DAY * 6;
-    public static final int CACHE_DURATION_ONE_WEEK = CACHE_DURATION_ONE_DAY * 7;
-
-    public static void setUrlDrawable(final ImageView imageView, final String url, int defaultResource) {
-        setUrlDrawable(imageView.getContext(), imageView, url, defaultResource, CACHE_DURATION_THREE_DAYS);
-    }
-
-    public static void setUrlDrawable(final ImageView imageView, final String url) {
-        setUrlDrawable(imageView.getContext(), imageView, url, null, CACHE_DURATION_THREE_DAYS, null);
-    }
-
+    
     public static void loadUrlDrawable(final Context context, final String url) {
-        setUrlDrawable(context, null, url, null, CACHE_DURATION_THREE_DAYS, null);
+        setUrlDrawable(context, null, url, null, CACHE_DURATION_THREE_DAYS,
+                null);
     }
-
-    public static void setUrlDrawable(final ImageView imageView, final String url, Drawable defaultDrawable) {
-        setUrlDrawable(imageView.getContext(), imageView, url, defaultDrawable, CACHE_DURATION_THREE_DAYS, null);
-    }
-
-    public static void setUrlDrawable(final ImageView imageView, final String url, int defaultResource, long cacheDurationMs) {
-        setUrlDrawable(imageView.getContext(), imageView, url, defaultResource, cacheDurationMs);
-    }
-
-    public static void loadUrlDrawable(final Context context, final String url, long cacheDurationMs) {
+    
+    public static void loadUrlDrawable(final Context context, final String url,
+            final long cacheDurationMs) {
         setUrlDrawable(context, null, url, null, cacheDurationMs, null);
     }
-
-    public static void setUrlDrawable(final ImageView imageView, final String url, Drawable defaultDrawable, long cacheDurationMs) {
-        setUrlDrawable(imageView.getContext(), imageView, url, defaultDrawable, cacheDurationMs, null);
-    }
-
-    private static void setUrlDrawable(final Context context, final ImageView imageView, final String url, int defaultResource, long cacheDurationMs) {
-        Drawable d = null;
-        if (defaultResource != 0)
-            d = imageView.getResources().getDrawable(defaultResource);
-        setUrlDrawable(context, imageView, url, d, cacheDurationMs, null);
-    }
-
-    public static void setUrlDrawable(final ImageView imageView, final String url, int defaultResource, UrlImageViewCallback callback) {
-        setUrlDrawable(imageView.getContext(), imageView, url, defaultResource, CACHE_DURATION_THREE_DAYS, callback);
-    }
-
-    public static void setUrlDrawable(final ImageView imageView, final String url, UrlImageViewCallback callback) {
-        setUrlDrawable(imageView.getContext(), imageView, url, null, CACHE_DURATION_THREE_DAYS, callback);
-    }
-
-    public static void loadUrlDrawable(final Context context, final String url, UrlImageViewCallback callback) {
-        setUrlDrawable(context, null, url, null, CACHE_DURATION_THREE_DAYS, callback);
-    }
-
-    public static void setUrlDrawable(final ImageView imageView, final String url, Drawable defaultDrawable, UrlImageViewCallback callback) {
-        setUrlDrawable(imageView.getContext(), imageView, url, defaultDrawable, CACHE_DURATION_THREE_DAYS, callback);
-    }
-
-    public static void setUrlDrawable(final ImageView imageView, final String url, int defaultResource, long cacheDurationMs, UrlImageViewCallback callback) {
-        setUrlDrawable(imageView.getContext(), imageView, url, defaultResource, cacheDurationMs, callback);
-    }
-
-    public static void loadUrlDrawable(final Context context, final String url, long cacheDurationMs, UrlImageViewCallback callback) {
+    
+    public static void loadUrlDrawable(final Context context, final String url,
+            final long cacheDurationMs, final UrlImageViewCallback callback) {
         setUrlDrawable(context, null, url, null, cacheDurationMs, callback);
     }
-
-    public static void setUrlDrawable(final ImageView imageView, final String url, Drawable defaultDrawable, long cacheDurationMs, UrlImageViewCallback callback) {
-        setUrlDrawable(imageView.getContext(), imageView, url, defaultDrawable, cacheDurationMs, callback);
-    }
-
-    private static void setUrlDrawable(final Context context, final ImageView imageView, final String url, int defaultResource, long cacheDurationMs, UrlImageViewCallback callback) {
-        Drawable d = null;
-        if (defaultResource != 0)
-            d = imageView.getResources().getDrawable(defaultResource);
-        setUrlDrawable(context, imageView, url, d, cacheDurationMs, callback);
-    }
-
-    private static boolean isNullOrEmpty(CharSequence s) {
-        return (s == null || s.equals("") || s.equals("null") || s.equals("NULL"));
-    }
-
-    private static boolean mHasCleaned = false;
-
-    public static String getFilenameForUrl(String url) {
-        return "" + url.hashCode() + ".urlimage";
-    }
-
-    private static void cleanup(Context context) {
-        if (mHasCleaned)
-            return;
-        mHasCleaned = true;
-        try {
-            // purge any *.urlimage files over a week old
-            String[] files = context.getFilesDir().list();
-            if (files == null)
-                return;
-            for (String file : files) {
-                if (!file.endsWith(".urlimage"))
-                    continue;
-
-                File f = new File(context.getFilesDir().getAbsolutePath() + '/' + file);
-                if (System.currentTimeMillis() > f.lastModified() + CACHE_DURATION_ONE_WEEK)
-                    f.delete();
-            }
-        }
-        catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
-
-    private static void setUrlDrawable(final Context context, final ImageView imageView, final String url, final Drawable defaultDrawable, long cacheDurationMs, final UrlImageViewCallback callback) {
-        cleanup(context);
-        // disassociate this ImageView from any pending downloads
-        if (isNullOrEmpty(url)) {
-            if (imageView != null)
-                imageView.setImageDrawable(defaultDrawable);
-            return;
-        }
-
-        WindowManager wm = (WindowManager)context.getSystemService(Context.WINDOW_SERVICE);
-        Display display = wm.getDefaultDisplay();
-        final int tw = display.getWidth();
-        final int th = display.getHeight();
-
-        if (mDeadCache == null)
-            mDeadCache = new UrlLruCache(getHeapSize(context) / 8);
-        Drawable drawable;
-        BitmapDrawable zd = mDeadCache.remove(url);
-        if (zd != null) {
-            // this drawable was resurrected, it should not be in the live cache
-            if (Constants.LOG_ENABLED)
-                Log.i(Constants.LOGTAG, "zombie load");
-            Assert.assertTrue(!mAllCache.contains(zd));
-            drawable = new ZombieDrawable(url, zd);
-        }
-        else {
-            drawable = mLiveCache.get(url);
-        }
-
-        if (drawable != null) {
-            if (Constants.LOG_ENABLED)
-                Log.i(Constants.LOGTAG, "Cache hit on: " + url);
-            if (imageView != null)
-                imageView.setImageDrawable(drawable);
-            if (callback != null)
-                callback.onLoaded(imageView, drawable, url, true);
-            return;
-        }
-        
-        // oh noes, at this point we definitely do not have the file available in memory
-        // let's prepare for an asynchronous load of the image.
-
-        final String filename = context.getFileStreamPath(getFilenameForUrl(url)).getAbsolutePath();
-
-        // null it while it is downloading
-        if (imageView != null)
-            imageView.setImageDrawable(defaultDrawable);
-
-        // since listviews reuse their views, we need to 
-        // take note of which url this view is waiting for.
-        // This may change rapidly as the list scrolls or is filtered, etc.
-        if (Constants.LOG_ENABLED)
-            Log.i(Constants.LOGTAG, "Waiting for " + url);
-        if (imageView != null)
-            mPendingViews.put(imageView, url);
-
-        ArrayList<ImageView> currentDownload = mPendingDownloads.get(url);
-        if (currentDownload != null) {
-            // Also, multiple vies may be waiting for this url.
-            // So, let's maintain a list of these views.
-            // When the url is downloaded, it sets the imagedrawable for
-            // every view in the list. It needs to also validate that
-            // the imageview is still waiting for this url.
-            if (imageView != null)
-                currentDownload.add(imageView);
-            return;
-        }
-
-        final ArrayList<ImageView> downloads = new ArrayList<ImageView>();
-        if (imageView != null)
-            downloads.add(imageView);
-        mPendingDownloads.put(url, downloads);
-
-        final int targetWidth = tw <= 0 ? Integer.MAX_VALUE : tw;
-        final int targetHeight = th <= 0 ? Integer.MAX_VALUE : th;
-        final Loader loader = new Loader() {
-            @Override
-            public void run() {
-                try {
-                    result = loadDrawableFromStream(context, url, filename, targetWidth, targetHeight);
-                }
-                catch (Exception ex) {
-                }
-            }
-        };
-
-        final Runnable completion = new Runnable() {
-            @Override
-            public void run() {
-                Assert.assertEquals(Looper.myLooper(), Looper.getMainLooper());
-                Drawable usableResult = loader.result;
-                if (usableResult == null)
-                    usableResult = defaultDrawable;
-                mPendingDownloads.remove(url);
-                mLiveCache.put(url, usableResult);
-                for (ImageView iv: downloads) {
-                    // validate the url it is waiting for
-                    String pendingUrl = mPendingViews.get(iv);
-                    if (!url.equals(pendingUrl)) {
-                        if (Constants.LOG_ENABLED)
-                            Log.i(Constants.LOGTAG, "Ignoring out of date request to update view for " + url);
-                        continue;
-                    }
-                    mPendingViews.remove(iv);
-                    if (usableResult != null) {
-                        //                        System.out.println(String.format("imageView: %dx%d, %dx%d", imageView.getMeasuredWidth(), imageView.getMeasuredHeight(), imageView.getWidth(), imageView.getHeight()));
-                        iv.setImageDrawable(usableResult);
-//                        System.out.println(String.format("imageView: %dx%d, %dx%d", imageView.getMeasuredWidth(), imageView.getMeasuredHeight(), imageView.getWidth(), imageView.getHeight()));
-                        if (callback != null)
-                            callback.onLoaded(iv, loader.result, url, false);
-                    }
-                }
-            }
-        };
-        
-
-        File file = new File(filename);
-        if (file.exists()) {
-            try {
-                if (cacheDurationMs == CACHE_DURATION_INFINITE || System.currentTimeMillis() < file.lastModified() + cacheDurationMs) {
-                    if (Constants.LOG_ENABLED)
-                        Log.i(Constants.LOGTAG, "File Cache hit on: " + url + ". " + (System.currentTimeMillis() - file.lastModified()) + "ms old.");
-                    
-                    AsyncTask<Void, Void, Void> fileloader = new AsyncTask<Void, Void, Void>() {
-                        protected Void doInBackground(Void[] params) {
-                            loader.run();
-                            return null;
-                        }
-                        protected void onPostExecute(Void result) {
-                            completion.run();
-                        }
-                    };
-                    executeTask(fileloader);
-                    return;
-                }
-                else {
-                    if (Constants.LOG_ENABLED)
-                        Log.i(Constants.LOGTAG, "File cache has expired. Refreshing.");
-                }
-            }
-            catch (Exception ex) {
-            }
-        }
-
-        mDownloader.download(context, url, filename, loader, completion);
-    }
-
-    private static abstract class Loader implements Runnable {
-        public Drawable result;
-    }
-
-    public static interface UrlDownloader {
-        public void download(Context context, String url, String filename, Runnable loader, Runnable completion);
-    }
-
-    private static UrlDownloader mDefaultDownloader = new UrlDownloader() {
-        @Override
-        public void download(final Context context, final String url, final String filename, final Runnable loader, final Runnable completion) {
-            AsyncTask<Void, Void, Void> downloader = new AsyncTask<Void, Void, Void>() {
-                @Override
-                protected Void doInBackground(Void... params) {
-                    try {
-                        InputStream is = null;
-                        if (url.startsWith(ContactsContract.Contacts.CONTENT_URI.toString())) {
-                            ContentResolver cr = context.getContentResolver();
-                            is = ContactsContract.Contacts.openContactPhotoInputStream(cr, Uri.parse(url));
-                        }
-                        else {
-                            URL u = new URL(url);
-                            HttpURLConnection urlConnection = (HttpURLConnection)u.openConnection();
-                            
-                            if (mRequestPropertiesCallback != null) {
-                                ArrayList<NameValuePair> props = mRequestPropertiesCallback.getHeadersForRequest(context, url);
-                                if (props != null) {
-                                    for (NameValuePair pair: props) {
-                                        urlConnection.addRequestProperty(pair.getName(), pair.getValue());
-                                    }
-                                }
-                            }
-
-                            if (urlConnection.getResponseCode() != HttpURLConnection.HTTP_OK)
-                                return null;
-                            is = urlConnection.getInputStream();
-                        }
-                        
-                        if (is != null) {
-                            FileOutputStream fos = new FileOutputStream(filename);
-                            copyStream(is, fos);
-                            fos.close();
-                            is.close();
-                        }
-                        loader.run();
-                        return null;
-                    }
-                    catch (Throwable e) {
-                        e.printStackTrace();
-                        return null;
-                    }
-                }
-
-                protected void onPostExecute(Void result) {
-                    completion.run();
-                }
-            };
-
-            executeTask(downloader);
-        }
-    };
     
-    static public interface RequestPropertiesCallback {
-        public ArrayList<NameValuePair> getHeadersForRequest(Context context, String url);
+    public static void loadUrlDrawable(final Context context, final String url,
+            final UrlImageViewCallback callback) {
+        setUrlDrawable(context, null, url, null, CACHE_DURATION_THREE_DAYS,
+                callback);
     }
     
-    static private RequestPropertiesCallback mRequestPropertiesCallback;
-    static public RequestPropertiesCallback getRequestPropertiesCallback() {
-        return mRequestPropertiesCallback;
+    private static void prepareResources(final Context context) {
+        if (mMetrics != null) {
+            return;
+        }
+        mMetrics = new DisplayMetrics();
+        final Activity act = (Activity) context;
+        act.getWindowManager().getDefaultDisplay().getMetrics(mMetrics);
+        final AssetManager mgr = context.getAssets();
+        mResources = new Resources(mgr, mMetrics, context.getResources()
+                .getConfiguration());
     }
     
-    static public void setRequestPropertiesCallback(RequestPropertiesCallback callback) {
+    public static void setRequestPropertiesCallback(
+            final RequestPropertiesCallback callback) {
         mRequestPropertiesCallback = callback;
     }
     
-    
-    public static void useDownloader(UrlDownloader downloader) {
-        mDownloader = downloader;
+    private static void setUrlDrawable(final Context context,
+            final ImageView imageView, final String url,
+            final Drawable defaultDrawable, final long cacheDurationMs,
+            final UrlImageViewCallback callback) {
+        cleanup(context);
+        // disassociate this ImageView from any pending downloads
+        if (isNullOrEmpty(url)) {
+            if (imageView != null) {
+                imageView.setImageDrawable(defaultDrawable);
+            }
+            return;
+        }
+        
+        final int tw = mMetrics.widthPixels;
+        final int th = mMetrics.heightPixels;
+        
+        if (mDeadCache == null) {
+            mDeadCache = new UrlLruCache(getHeapSize(context) / 8);
+        }
+        Drawable drawable;
+        final BitmapDrawable zombieDrawable = mDeadCache.remove(url);
+        if (zombieDrawable != null) {
+            // this drawable was resurrected, it should not be in the live cache
+            if (Constants.LOG_ENABLED) {
+                Log.i(Constants.LOGTAG, "zombie load");
+            }
+            Assert.assertTrue(!mAllCache.contains(zombieDrawable));
+            drawable = new ZombieDrawable(url, zombieDrawable);
+        } else {
+            drawable = mLiveCache.get(url);
+        }
+        
+        if (drawable != null) {
+            if (Constants.LOG_ENABLED) {
+                Log.i(Constants.LOGTAG, "Cache hit on: " + url);
+            }
+            if (imageView != null) {
+                imageView.setImageDrawable(drawable);
+            }
+            if (callback != null) {
+                callback.onLoaded(imageView, drawable, url, true);
+            }
+        } else {
+            
+            // oh noes, at this point we definitely do not have the file
+            // available
+            // in memory let's prepare for an asynchronous load of the image.
+            final String filename = context.getFileStreamPath(
+                    getFilenameForUrl(url)).getAbsolutePath();
+            
+            // null it while it is downloading
+            if (imageView != null) {
+                imageView.setImageDrawable(defaultDrawable);
+            }
+            
+            // since listviews reuse their views, we need to
+            // take note of which url this view is waiting for.
+            // This may change rapidly as the list scrolls or is filtered, etc.
+            if (Constants.LOG_ENABLED) {
+                Log.i(Constants.LOGTAG, "Waiting for " + url);
+            }
+            if (imageView != null) {
+                mPendingViews.put(imageView, url);
+            }
+            
+            final ArrayList<ImageView> currentDownload = mPendingDownloads
+                    .get(url);
+            if (currentDownload != null) {
+                // Also, multiple views may be waiting for this url.
+                // So, let's maintain a list of these views.
+                // When the url is downloaded, it sets the imagedrawable for
+                // every view in the list. It needs to also validate that
+                // the imageview is still waiting for this url.
+                if (imageView != null) {
+                    currentDownload.add(imageView);
+                }
+            } else {
+                final ArrayList<ImageView> downloads = new ArrayList<ImageView>();
+                if (imageView != null) {
+                    downloads.add(imageView);
+                }
+                mPendingDownloads.put(url, downloads);
+                
+                final int targetWidth = tw <= 0 ? Integer.MAX_VALUE : tw;
+                final int targetHeight = th <= 0 ? Integer.MAX_VALUE : th;
+                final Loader loader = new DefaultLoader(context, filename,
+                        targetWidth, targetHeight, url);
+                
+                final Runnable completion = new OnImageLoadRunnable(url,
+                        loader, downloads, callback, defaultDrawable);
+                
+                final File file = new File(filename);
+                if (file.exists()) {
+                    try {
+                        if (cacheDurationMs == CACHE_DURATION_INFINITE
+                                || System.currentTimeMillis() < file
+                                        .lastModified() + cacheDurationMs) {
+                            if (Constants.LOG_ENABLED) {
+                                Log.i(Constants.LOGTAG, "File Cache hit on: "
+                                        + url + ". "
+                                        + (System.currentTimeMillis() - file
+                                                .lastModified()) + "ms old.");
+                            }
+                            
+                            executeTask(new AsyncLoadFileTask(loader,
+                                    completion));
+                        } else {
+                            if (Constants.LOG_ENABLED) {
+                                Log.i(Constants.LOGTAG,
+                                        "File cache has expired. Refreshing.");
+                            }
+                        }
+                    } catch (final Exception ex) {
+                        if (Constants.LOG_ENABLED) {
+                            Log.e(Constants.LOGTAG, "Exception", ex);
+                        }
+                    }
+                }
+                mDownloader.download(context, url, filename, loader,
+                        completion);
+            }
+        }
     }
-
+    
+    private static void setUrlDrawable(final Context context,
+            final ImageView imageView, final String url,
+            final int defaultResource, final long cacheDurationMs) {
+        Drawable d = null;
+        if (defaultResource != 0) {
+            d = imageView.getResources().getDrawable(defaultResource);
+        }
+        setUrlDrawable(context, imageView, url, d, cacheDurationMs, null);
+    }
+    
+    private static void setUrlDrawable(final Context context,
+            final ImageView imageView, final String url,
+            final int defaultResource, final long cacheDurationMs,
+            final UrlImageViewCallback callback) {
+        Drawable d = null;
+        if (defaultResource != 0) {
+            d = imageView.getResources().getDrawable(defaultResource);
+        }
+        setUrlDrawable(context, imageView, url, d, cacheDurationMs, callback);
+    }
+    
+    public static void setUrlDrawable(final ImageView imageView,
+            final String url) {
+        setUrlDrawable(imageView.getContext(), imageView, url, null,
+                CACHE_DURATION_THREE_DAYS, null);
+    }
+    
+    public static void setUrlDrawable(final ImageView imageView,
+            final String url, final Drawable defaultDrawable) {
+        setUrlDrawable(imageView.getContext(), imageView, url, defaultDrawable,
+                CACHE_DURATION_THREE_DAYS, null);
+    }
+    
+    public static void setUrlDrawable(final ImageView imageView,
+            final String url, final Drawable defaultDrawable,
+            final long cacheDurationMs) {
+        setUrlDrawable(imageView.getContext(), imageView, url, defaultDrawable,
+                cacheDurationMs, null);
+    }
+    
+    public static void setUrlDrawable(final ImageView imageView,
+            final String url, final Drawable defaultDrawable,
+            final long cacheDurationMs, final UrlImageViewCallback callback) {
+        setUrlDrawable(imageView.getContext(), imageView, url, defaultDrawable,
+                cacheDurationMs, callback);
+    }
+    
+    public static void setUrlDrawable(final ImageView imageView,
+            final String url, final Drawable defaultDrawable,
+            final UrlImageViewCallback callback) {
+        setUrlDrawable(imageView.getContext(), imageView, url, defaultDrawable,
+                CACHE_DURATION_THREE_DAYS, callback);
+    }
+    
+    public static void setUrlDrawable(final ImageView imageView,
+            final String url, final int defaultResource) {
+        setUrlDrawable(imageView.getContext(), imageView, url, defaultResource,
+                CACHE_DURATION_THREE_DAYS);
+    }
+    
+    public static void setUrlDrawable(final ImageView imageView,
+            final String url, final int defaultResource,
+            final long cacheDurationMs) {
+        setUrlDrawable(imageView.getContext(), imageView, url, defaultResource,
+                cacheDurationMs);
+    }
+    
+    public static void setUrlDrawable(final ImageView imageView,
+            final String url, final int defaultResource,
+            final long cacheDurationMs, final UrlImageViewCallback callback) {
+        setUrlDrawable(imageView.getContext(), imageView, url, defaultResource,
+                cacheDurationMs, callback);
+    }
+    
+    public static void setUrlDrawable(final ImageView imageView,
+            final String url, final int defaultResource,
+            final UrlImageViewCallback callback) {
+        setUrlDrawable(imageView.getContext(), imageView, url, defaultResource,
+                CACHE_DURATION_THREE_DAYS, callback);
+    }
+    
+    public static void setUrlDrawable(final ImageView imageView,
+            final String url, final UrlImageViewCallback callback) {
+        setUrlDrawable(imageView.getContext(), imageView, url, null,
+                CACHE_DURATION_THREE_DAYS, callback);
+    }
+    
     public static void useDefaultDownloader() {
         mDownloader = mDefaultDownloader;
     }
     
-    public static UrlDownloader getDefaultDownloader() {
-        return mDownloader;
+    public static void useDownloader(final UrlDownloader downloader) {
+        mDownloader = downloader;
     }
-
-    private static UrlImageCache mLiveCache = UrlImageCache.getInstance();
-
-    private static UrlLruCache mDeadCache;
-    private static HashSet<BitmapDrawable> mAllCache = new HashSet<BitmapDrawable>();
-    private static int getHeapSize(Context context) {
-        return ((ActivityManager)context.getSystemService(Context.ACTIVITY_SERVICE)).getMemoryClass() * 1024 * 1024;
-    }
-    
-    private static class ZombieDrawable extends WrapperDrawable {
-        public ZombieDrawable(String url, BitmapDrawable drawable) {
-            super(drawable);
-            mUrl = url;
-
-            mAllCache.add(drawable);
-            mDeadCache.remove(url);
-            mLiveCache.put(url, this);
-        }
-        
-        String mUrl;
-        
-        @Override
-        protected void finalize() throws Throwable {
-            super.finalize();
-
-            mDeadCache.put(mUrl, mDrawable);
-            mAllCache.remove(mDrawable);
-            mLiveCache.remove(mUrl);
-            if (Constants.LOG_ENABLED)
-                Log.i(Constants.LOGTAG, "Zombie GC event");
-            System.gc();
-        }
-    }
-
-
-    private static UrlDownloader mDownloader = mDefaultDownloader;
-
-    private static void executeTask(AsyncTask<Void, Void, Void> task) {
-        if (Build.VERSION.SDK_INT < Constants.HONEYCOMB)
-            task.execute();
-        else
-            executeTaskHoneycomb(task);
-    }
-    
-    @TargetApi(Constants.HONEYCOMB)
-    private static void executeTaskHoneycomb(AsyncTask<Void, Void, Void> task) {
-        task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
-    }
-
-    private static Hashtable<ImageView, String> mPendingViews = new Hashtable<ImageView, String>();
-    private static Hashtable<String, ArrayList<ImageView>> mPendingDownloads = new Hashtable<String, ArrayList<ImageView>>();
 }

--- a/UrlImageViewHelper/src/com/koushikdutta/urlimageviewhelper/UrlImageViewHelper.java
+++ b/UrlImageViewHelper/src/com/koushikdutta/urlimageviewhelper/UrlImageViewHelper.java
@@ -41,9 +41,8 @@ import android.widget.ImageView;
 
 public final class UrlImageViewHelper {
 
-    public static int copyStream(InputStream input, OutputStream output) throws IOException
-    {
-        byte[] stuff = new byte[1024];
+    public static int copyStream(final InputStream input, final OutputStream output) throws IOException {
+        final byte[] stuff = new byte[1024];
         int read = 0;
         int total = 0;
         while ((read = input.read(stuff)) != -1)
@@ -56,21 +55,22 @@ public final class UrlImageViewHelper {
 
     static Resources mResources;
     static DisplayMetrics mMetrics;
-    private static void prepareResources(Context context) {
-        if (mMetrics != null)
+    private static void prepareResources(final Context context) {
+        if (mMetrics != null) {
             return;
+        }
         mMetrics = new DisplayMetrics();
-        Activity act = (Activity)context;
+        final Activity act = (Activity)context;
         act.getWindowManager().getDefaultDisplay().getMetrics(mMetrics);
-        AssetManager mgr = context.getAssets();
+        final AssetManager mgr = context.getAssets();
         mResources = new Resources(mgr, mMetrics, context.getResources().getConfiguration());
     }
 
-    private static Drawable loadDrawableFromStream(Context context, String url, String filename, int targetWidth, int targetHeight) {
+    private static Drawable loadDrawableFromStream(final Context context, final String url, final String filename, final int targetWidth, final int targetHeight) {
         prepareResources(context);
-        
-//        Log.v(Constants.LOGTAG,targetWidth);
-//        Log.v(Constants.LOGTAG,targetHeight);
+
+        //        Log.v(Constants.LOGTAG,targetWidth);
+        //        Log.v(Constants.LOGTAG,targetHeight);
         try {
             BitmapFactory.Options o = new BitmapFactory.Options();
             o.inJustDecodeBounds = true;
@@ -86,12 +86,12 @@ public final class UrlImageViewHelper {
             o = new Options();
             o.inSampleSize = 1 << scale;
             final Bitmap bitmap = BitmapFactory.decodeStream(stream, null, o);
-            if (Constants.LOG_ENABLED)
+            if (Constants.LOG_ENABLED) {
                 Log.i(Constants.LOGTAG, String.format("Loaded bitmap (%dx%d).", bitmap.getWidth(), bitmap.getHeight()));
-            BitmapDrawable bd = new BitmapDrawable(mResources, bitmap);
+            }
+            final BitmapDrawable bd = new BitmapDrawable(mResources, bitmap);
             return new ZombieDrawable(url, bd);
-        }
-        catch (IOException e) {
+        } catch (final IOException e) {
             return null;
         }
     }
@@ -105,10 +105,28 @@ public final class UrlImageViewHelper {
     public static final int CACHE_DURATION_SIX_DAYS = CACHE_DURATION_ONE_DAY * 6;
     public static final int CACHE_DURATION_ONE_WEEK = CACHE_DURATION_ONE_DAY * 7;
 
-    public static void setUrlDrawable(final ImageView imageView, final String url, int defaultResource) {
+    /**
+     * Download and shrink an Image located at a specified URL, and display it
+     * in the provided {@link ImageView}.
+     *
+     * @param imageView The {@link ImageView} to display the image to after it
+     *            is loaded.
+     * @param url The URL of the image that should be loaded.
+     * @param defaultResource The Android resid of the {@link Drawable} that
+     *            should be displayed while the image is being downloaded.
+     */
+    public static void setUrlDrawable(final ImageView imageView, final String url, final int defaultResource) {
         setUrlDrawable(imageView.getContext(), imageView, url, defaultResource, CACHE_DURATION_THREE_DAYS);
     }
 
+    /**
+     * Download and shrink an Image located at a specified URL, and display it
+     * in the provided {@link ImageView} once it finishes loading.
+     *
+     * @param imageView The {@link ImageView} to display the image to after it
+     *            is loaded.
+     * @param url The URL of the image that should be loaded.
+     */
     public static void setUrlDrawable(final ImageView imageView, final String url) {
         setUrlDrawable(imageView.getContext(), imageView, url, null, CACHE_DURATION_THREE_DAYS, null);
     }
@@ -117,168 +135,357 @@ public final class UrlImageViewHelper {
         setUrlDrawable(context, null, url, null, CACHE_DURATION_THREE_DAYS, null);
     }
 
-    public static void setUrlDrawable(final ImageView imageView, final String url, Drawable defaultDrawable) {
+    /**
+     * Download and shrink an Image located at a specified URL, and display it
+     * in the provided {@link ImageView}.
+     *
+     * @param imageView The {@link ImageView} to display the image to after it
+     *            is loaded.
+     * @param url The URL of the image that should be loaded.
+     * @param defaultDrawable A {@link Drawable} that should be displayed in
+     *            {@code imageView} while the image has not been loaded. This
+     *            image will also be displayed if the image fails to load. This
+     *            can be set to {@code null}.
+     */
+    public static void setUrlDrawable(final ImageView imageView, final String url, final Drawable defaultDrawable) {
         setUrlDrawable(imageView.getContext(), imageView, url, defaultDrawable, CACHE_DURATION_THREE_DAYS, null);
     }
 
-    public static void setUrlDrawable(final ImageView imageView, final String url, int defaultResource, long cacheDurationMs) {
+    /**
+     * Download and shrink an Image located at a specified URL, and display it
+     * in the provided {@link ImageView}.
+     *
+     * @param imageView The {@link ImageView} to display the image to after it
+     *            is loaded.
+     * @param url The URL of the image that should be loaded.
+     * @param defaultResource The Android resid of the {@link Drawable} that
+     *            should be displayed while the image is being downloaded.
+     * @param cacheDurationMs The length of time, in milliseconds, that this
+     *            image should be cached locally.
+     */
+    public static void setUrlDrawable(final ImageView imageView, final String url, final int defaultResource, final long cacheDurationMs) {
         setUrlDrawable(imageView.getContext(), imageView, url, defaultResource, cacheDurationMs);
     }
 
-    public static void loadUrlDrawable(final Context context, final String url, long cacheDurationMs) {
+    public static void loadUrlDrawable(final Context context, final String url, final long cacheDurationMs) {
         setUrlDrawable(context, null, url, null, cacheDurationMs, null);
     }
 
-    public static void setUrlDrawable(final ImageView imageView, final String url, Drawable defaultDrawable, long cacheDurationMs) {
+    /**
+     * Download and shrink an Image located at a specified URL, and display it
+     * in the provided {@link ImageView}.
+     *
+     * @param imageView The {@link ImageView} to display the image to after it
+     *            is loaded.
+     * @param url The URL of the image that should be loaded.
+     * @param defaultDrawable A {@link Drawable} that should be displayed in
+     *            {@code imageView} while the image has not been loaded. This
+     *            image will also be displayed if the image fails to load. This
+     *            can be set to {@code null}.
+     * @param cacheDurationMs The length of time, in milliseconds, that this
+     *            image should be cached locally.
+     */
+    public static void setUrlDrawable(final ImageView imageView, final String url, final Drawable defaultDrawable, final long cacheDurationMs) {
         setUrlDrawable(imageView.getContext(), imageView, url, defaultDrawable, cacheDurationMs, null);
     }
 
-    private static void setUrlDrawable(final Context context, final ImageView imageView, final String url, int defaultResource, long cacheDurationMs) {
+    /**
+     * Download and shrink an Image located at a specified URL, and display it
+     * in the provided {@link ImageView}.
+     *
+     * @param context A {@link Context} to allow setUrlDrawable to load and save
+     *            files.
+     * @param imageView The {@link ImageView} to display the image to after it
+     *            is loaded.
+     * @param url The URL of the image that should be loaded.
+     * @param defaultResource The Android resid of the {@link Drawable} that
+     *            should be displayed while the image is being downloaded.
+     * @param cacheDurationMs The length of time, in milliseconds, that this
+     *            image should be cached locally.
+     */
+    private static void setUrlDrawable(final Context context, final ImageView imageView, final String url, final int defaultResource, final long cacheDurationMs) {
         Drawable d = null;
-        if (defaultResource != 0)
+        if (defaultResource != 0) {
             d = imageView.getResources().getDrawable(defaultResource);
+        }
         setUrlDrawable(context, imageView, url, d, cacheDurationMs, null);
     }
 
-    public static void setUrlDrawable(final ImageView imageView, final String url, int defaultResource, UrlImageViewCallback callback) {
+    /**
+     * Download and shrink an Image located at a specified URL, and display it
+     * in the provided {@link ImageView}.
+     *
+     * @param imageView The {@link ImageView} to display the image to after it
+     *            is loaded.
+     * @param url The URL of the image that should be loaded.
+     * @param defaultResource The Android resid of the {@link Drawable} that
+     *            should be displayed while the image is being downloaded.
+     * @param callback An instance of {@link UrlImageViewCallback} that is
+     *            called when the image successfully finishes loading. This
+     *            value can be null.
+     */
+    public static void setUrlDrawable(final ImageView imageView, final String url, final int defaultResource, final UrlImageViewCallback callback) {
         setUrlDrawable(imageView.getContext(), imageView, url, defaultResource, CACHE_DURATION_THREE_DAYS, callback);
     }
 
-    public static void setUrlDrawable(final ImageView imageView, final String url, UrlImageViewCallback callback) {
+    /**
+     * Download and shrink an Image located at a specified URL, and display it
+     * in the provided {@link ImageView}.
+     *
+     * @param imageView The {@link ImageView} to display the image to after it
+     *            is loaded.
+     * @param url The URL of the image that should be loaded.
+     * @param callback An instance of {@link UrlImageViewCallback} that is
+     *            called when the image successfully finishes loading. This
+     *            value can be null.
+     */
+    public static void setUrlDrawable(final ImageView imageView, final String url, final UrlImageViewCallback callback) {
         setUrlDrawable(imageView.getContext(), imageView, url, null, CACHE_DURATION_THREE_DAYS, callback);
     }
 
-    public static void loadUrlDrawable(final Context context, final String url, UrlImageViewCallback callback) {
+    public static void loadUrlDrawable(final Context context, final String url, final UrlImageViewCallback callback) {
         setUrlDrawable(context, null, url, null, CACHE_DURATION_THREE_DAYS, callback);
     }
 
-    public static void setUrlDrawable(final ImageView imageView, final String url, Drawable defaultDrawable, UrlImageViewCallback callback) {
+    /**
+     * Download and shrink an Image located at a specified URL, and display it
+     * in the provided {@link ImageView}.
+     *
+     * @param imageView The {@link ImageView} to display the image to after it
+     *            is loaded.
+     * @param url The URL of the image that should be loaded.
+     * @param defaultDrawable A {@link Drawable} that should be displayed in
+     *            {@code imageView} while the image has not been loaded. This
+     *            image will also be displayed if the image fails to load. This
+     *            can be set to {@code null}.
+     * @param callback An instance of {@link UrlImageViewCallback} that is
+     *            called when the image successfully finishes loading. This
+     *            value can be null.
+     */
+    public static void setUrlDrawable(final ImageView imageView, final String url, final Drawable defaultDrawable, final UrlImageViewCallback callback) {
         setUrlDrawable(imageView.getContext(), imageView, url, defaultDrawable, CACHE_DURATION_THREE_DAYS, callback);
     }
 
-    public static void setUrlDrawable(final ImageView imageView, final String url, int defaultResource, long cacheDurationMs, UrlImageViewCallback callback) {
+    /**
+     * Download and shrink an Image located at a specified URL, and display it
+     * in the provided {@link ImageView}.
+     *
+     * @param imageView The {@link ImageView} to display the image to after it
+     *            is loaded.
+     * @param url The URL of the image that should be loaded.
+     * @param defaultResource The Android resid of the {@link Drawable} that
+     *            should be displayed while the image is being downloaded.
+     * @param cacheDurationMs The length of time, in milliseconds, that this
+     *            image should be cached locally.
+     * @param callback An instance of {@link UrlImageViewCallback} that is
+     *            called when the image successfully finishes loading. This
+     *            value can be null.
+     */
+    public static void setUrlDrawable(final ImageView imageView, final String url, final int defaultResource, final long cacheDurationMs, final UrlImageViewCallback callback) {
         setUrlDrawable(imageView.getContext(), imageView, url, defaultResource, cacheDurationMs, callback);
     }
 
-    public static void loadUrlDrawable(final Context context, final String url, long cacheDurationMs, UrlImageViewCallback callback) {
+    public static void loadUrlDrawable(final Context context, final String url, final long cacheDurationMs, final UrlImageViewCallback callback) {
         setUrlDrawable(context, null, url, null, cacheDurationMs, callback);
     }
 
-    public static void setUrlDrawable(final ImageView imageView, final String url, Drawable defaultDrawable, long cacheDurationMs, UrlImageViewCallback callback) {
+    /**
+     * Download and shrink an Image located at a specified URL, and display it
+     * in the provided {@link ImageView}.
+     *
+     * @param imageView The {@link ImageView} to display the image to after it
+     *            is loaded.
+     * @param url The URL of the image that should be loaded.
+     * @param defaultDrawable A {@link Drawable} that should be displayed in
+     *            {@code imageView} while the image has not been loaded. This
+     *            image will also be displayed if the image fails to load. This
+     *            can be set to {@code null}.
+     * @param cacheDurationMs The length of time, in milliseconds, that this
+     *            image should be cached locally.
+     * @param callback An instance of {@link UrlImageViewCallback} that is
+     *            called when the image successfully finishes loading. This
+     *            value can be null.
+     */
+    public static void setUrlDrawable(final ImageView imageView, final String url, final Drawable defaultDrawable, final long cacheDurationMs, final UrlImageViewCallback callback) {
         setUrlDrawable(imageView.getContext(), imageView, url, defaultDrawable, cacheDurationMs, callback);
     }
 
-    private static void setUrlDrawable(final Context context, final ImageView imageView, final String url, int defaultResource, long cacheDurationMs, UrlImageViewCallback callback) {
+    /**
+     * Download and shrink an Image located at a specified URL, and display it
+     * in the provided {@link ImageView}.
+     *
+     * @param context A {@link Context} to allow setUrlDrawable to load and save
+     *            files.
+     * @param imageView The {@link ImageView} to display the image to after it
+     *            is loaded.
+     * @param url The URL of the image that should be loaded.
+     * @param defaultResource The Android resid of the {@link Drawable} that
+     *            should be displayed while the image is being downloaded.
+     * @param cacheDurationMs The length of time, in milliseconds, that this
+     *            image should be cached locally.
+     * @param callback An instance of {@link UrlImageViewCallback} that is
+     *            called when the image successfully finishes loading. This
+     *            value can be null.
+     */
+    private static void setUrlDrawable(final Context context, final ImageView imageView, final String url, final int defaultResource, final long cacheDurationMs, final UrlImageViewCallback callback) {
         Drawable d = null;
-        if (defaultResource != 0)
+        if (defaultResource != 0) {
             d = imageView.getResources().getDrawable(defaultResource);
+        }
         setUrlDrawable(context, imageView, url, d, cacheDurationMs, callback);
     }
 
-    private static boolean isNullOrEmpty(CharSequence s) {
+    private static boolean isNullOrEmpty(final CharSequence s) {
         return (s == null || s.equals("") || s.equals("null") || s.equals("NULL"));
     }
 
     private static boolean mHasCleaned = false;
 
-    public static String getFilenameForUrl(String url) {
-        return "" + url.hashCode() + ".urlimage";
+    public static String getFilenameForUrl(final String url) {
+        return url.hashCode() + ".urlimage";
     }
 
-    private static void cleanup(Context context) {
-        if (mHasCleaned)
+    private static void cleanup(final Context context) {
+        if (mHasCleaned) {
             return;
+        }
         mHasCleaned = true;
         try {
             // purge any *.urlimage files over a week old
-            String[] files = context.getFilesDir().list();
-            if (files == null)
+            final String[] files = context.getFilesDir().list();
+            if (files == null) {
                 return;
-            for (String file : files) {
-                if (!file.endsWith(".urlimage"))
-                    continue;
-
-                File f = new File(context.getFilesDir().getAbsolutePath() + '/' + file);
-                if (System.currentTimeMillis() > f.lastModified() + CACHE_DURATION_ONE_WEEK)
-                    f.delete();
             }
-        }
-        catch (Exception e) {
+            for (final String file : files) {
+                if (!file.endsWith(".urlimage")) {
+                    continue;
+                }
+
+                final File f = new File(context.getFilesDir().getAbsolutePath() + '/' + file);
+                if (System.currentTimeMillis() > f.lastModified() + CACHE_DURATION_ONE_WEEK) {
+                    f.delete();
+                }
+            }
+        } catch (final Exception e) {
             e.printStackTrace();
         }
     }
 
-    private static void setUrlDrawable(final Context context, final ImageView imageView, final String url, final Drawable defaultDrawable, long cacheDurationMs, final UrlImageViewCallback callback) {
+    /**
+     * Download and shrink an Image located at a specified URL, and display it
+     * in the provided {@link ImageView}.
+     *
+     * @param context A {@link Context} to allow setUrlDrawable to load and save
+     *            files.
+     * @param imageView The {@link ImageView} to display the image to after it
+     *            is loaded.
+     * @param url The URL of the image that should be loaded.
+     * @param defaultDrawable A {@link Drawable} that should be displayed in
+     *            {@code imageView} while the image has not been loaded. This
+     *            image will also be displayed if the image fails to load. This
+     *            can be set to {@code null}.
+     * @param cacheDurationMs The length of time, in milliseconds, that this
+     *            image should be cached locally.
+     * @param callback An instance of {@link UrlImageViewCallback} that is
+     *            called when the image successfully finishes loading. This
+     *            value can be null.
+     */
+    @SuppressWarnings("deprecation")
+    private static void setUrlDrawable(final Context context, final ImageView imageView, final String url, final Drawable defaultDrawable, final long cacheDurationMs, final UrlImageViewCallback callback) {
         cleanup(context);
         // disassociate this ImageView from any pending downloads
         if (isNullOrEmpty(url)) {
-            if (imageView != null)
+            if (imageView != null) {
                 imageView.setImageDrawable(defaultDrawable);
+            }
             return;
         }
 
-        WindowManager wm = (WindowManager)context.getSystemService(Context.WINDOW_SERVICE);
-        Display display = wm.getDefaultDisplay();
-        final int tw = display.getWidth();
-        final int th = display.getHeight();
+        /*
+         * There are states wherein setUrlDrawable(...) can be called before
+         * mMetrics is initialized. In these cases, we'll need to use the
+         * deprecated Display.getWidth() and Display.getHeight(), because their
+         * alternative, Display.getSize(Point), only becomes available at API
+         * 13.
+         */
+        final int tw;
+        final int th;
+        if (mMetrics == null) {
+            final WindowManager wm = (WindowManager)context.getSystemService(Context.WINDOW_SERVICE);
+            final Display display = wm.getDefaultDisplay();
+            tw = display.getWidth();
+            th = display.getHeight();
+        } else {
+            tw = mMetrics.widthPixels;
+            th = mMetrics.heightPixels;
+        }
 
-        if (mDeadCache == null)
+        if (mDeadCache == null) {
             mDeadCache = new UrlLruCache(getHeapSize(context) / 8);
+        }
         Drawable drawable;
-        BitmapDrawable zd = mDeadCache.remove(url);
+        final BitmapDrawable zd = mDeadCache.remove(url);
         if (zd != null) {
             // this drawable was resurrected, it should not be in the live cache
-            if (Constants.LOG_ENABLED)
+            if (Constants.LOG_ENABLED) {
                 Log.i(Constants.LOGTAG, "zombie load");
+            }
             Assert.assertTrue(!mAllCache.contains(zd));
             drawable = new ZombieDrawable(url, zd);
-        }
-        else {
+        } else {
             drawable = mLiveCache.get(url);
         }
 
         if (drawable != null) {
-            if (Constants.LOG_ENABLED)
+            if (Constants.LOG_ENABLED) {
                 Log.i(Constants.LOGTAG, "Cache hit on: " + url);
-            if (imageView != null)
+            }
+            if (imageView != null) {
                 imageView.setImageDrawable(drawable);
-            if (callback != null)
+            }
+            if (callback != null) {
                 callback.onLoaded(imageView, drawable, url, true);
+            }
             return;
         }
-        
+
         // oh noes, at this point we definitely do not have the file available in memory
         // let's prepare for an asynchronous load of the image.
 
         final String filename = context.getFileStreamPath(getFilenameForUrl(url)).getAbsolutePath();
 
         // null it while it is downloading
-        if (imageView != null)
+        if (imageView != null) {
             imageView.setImageDrawable(defaultDrawable);
+        }
 
-        // since listviews reuse their views, we need to 
+        // since listviews reuse their views, we need to
         // take note of which url this view is waiting for.
         // This may change rapidly as the list scrolls or is filtered, etc.
-        if (Constants.LOG_ENABLED)
+        if (Constants.LOG_ENABLED) {
             Log.i(Constants.LOGTAG, "Waiting for " + url);
-        if (imageView != null)
+        }
+        if (imageView != null) {
             mPendingViews.put(imageView, url);
+        }
 
-        ArrayList<ImageView> currentDownload = mPendingDownloads.get(url);
+        final ArrayList<ImageView> currentDownload = mPendingDownloads.get(url);
         if (currentDownload != null) {
             // Also, multiple vies may be waiting for this url.
             // So, let's maintain a list of these views.
             // When the url is downloaded, it sets the imagedrawable for
             // every view in the list. It needs to also validate that
             // the imageview is still waiting for this url.
-            if (imageView != null)
+            if (imageView != null) {
                 currentDownload.add(imageView);
+            }
             return;
         }
 
         final ArrayList<ImageView> downloads = new ArrayList<ImageView>();
-        if (imageView != null)
+        if (imageView != null) {
             downloads.add(imageView);
+        }
         mPendingDownloads.put(url, downloads);
 
         final int targetWidth = tw <= 0 ? Integer.MAX_VALUE : tw;
@@ -289,7 +496,7 @@ public final class UrlImageViewHelper {
                 try {
                     result = loadDrawableFromStream(context, url, filename, targetWidth, targetHeight);
                 }
-                catch (Exception ex) {
+                catch (final Exception ex) {
                 }
             }
         };
@@ -299,44 +506,50 @@ public final class UrlImageViewHelper {
             public void run() {
                 Assert.assertEquals(Looper.myLooper(), Looper.getMainLooper());
                 Drawable usableResult = loader.result;
-                if (usableResult == null)
+                if (usableResult == null) {
                     usableResult = defaultDrawable;
+                }
                 mPendingDownloads.remove(url);
                 mLiveCache.put(url, usableResult);
-                for (ImageView iv: downloads) {
+                for (final ImageView iv: downloads) {
                     // validate the url it is waiting for
-                    String pendingUrl = mPendingViews.get(iv);
+                    final String pendingUrl = mPendingViews.get(iv);
                     if (!url.equals(pendingUrl)) {
-                        if (Constants.LOG_ENABLED)
+                        if (Constants.LOG_ENABLED) {
                             Log.i(Constants.LOGTAG, "Ignoring out of date request to update view for " + url);
+                        }
                         continue;
                     }
                     mPendingViews.remove(iv);
                     if (usableResult != null) {
                         //                        System.out.println(String.format("imageView: %dx%d, %dx%d", imageView.getMeasuredWidth(), imageView.getMeasuredHeight(), imageView.getWidth(), imageView.getHeight()));
                         iv.setImageDrawable(usableResult);
-//                        System.out.println(String.format("imageView: %dx%d, %dx%d", imageView.getMeasuredWidth(), imageView.getMeasuredHeight(), imageView.getWidth(), imageView.getHeight()));
-                        if (callback != null)
+                        //                        System.out.println(String.format("imageView: %dx%d, %dx%d", imageView.getMeasuredWidth(), imageView.getMeasuredHeight(), imageView.getWidth(), imageView.getHeight()));
+                        if (callback != null) {
                             callback.onLoaded(iv, loader.result, url, false);
+                        }
                     }
                 }
             }
         };
-        
 
-        File file = new File(filename);
+
+        final File file = new File(filename);
         if (file.exists()) {
             try {
                 if (cacheDurationMs == CACHE_DURATION_INFINITE || System.currentTimeMillis() < file.lastModified() + cacheDurationMs) {
-                    if (Constants.LOG_ENABLED)
+                    if (Constants.LOG_ENABLED) {
                         Log.i(Constants.LOGTAG, "File Cache hit on: " + url + ". " + (System.currentTimeMillis() - file.lastModified()) + "ms old.");
-                    
-                    AsyncTask<Void, Void, Void> fileloader = new AsyncTask<Void, Void, Void>() {
-                        protected Void doInBackground(Void[] params) {
+                    }
+
+                    final AsyncTask<Void, Void, Void> fileloader = new AsyncTask<Void, Void, Void>() {
+                        @Override
+                        protected Void doInBackground(final Void... params) {
                             loader.run();
                             return null;
                         }
-                        protected void onPostExecute(Void result) {
+                        @Override
+                        protected void onPostExecute(final Void result) {
                             completion.run();
                         }
                     };
@@ -344,11 +557,12 @@ public final class UrlImageViewHelper {
                     return;
                 }
                 else {
-                    if (Constants.LOG_ENABLED)
+                    if (Constants.LOG_ENABLED) {
                         Log.i(Constants.LOGTAG, "File cache has expired. Refreshing.");
+                    }
                 }
             }
-            catch (Exception ex) {
+            catch (final Exception ex) {
             }
         }
 
@@ -366,35 +580,36 @@ public final class UrlImageViewHelper {
     private static UrlDownloader mDefaultDownloader = new UrlDownloader() {
         @Override
         public void download(final Context context, final String url, final String filename, final Runnable loader, final Runnable completion) {
-            AsyncTask<Void, Void, Void> downloader = new AsyncTask<Void, Void, Void>() {
+            final AsyncTask<Void, Void, Void> downloader = new AsyncTask<Void, Void, Void>() {
                 @Override
-                protected Void doInBackground(Void... params) {
+                protected Void doInBackground(final Void... params) {
                     try {
                         InputStream is = null;
                         if (url.startsWith(ContactsContract.Contacts.CONTENT_URI.toString())) {
-                            ContentResolver cr = context.getContentResolver();
+                            final ContentResolver cr = context.getContentResolver();
                             is = ContactsContract.Contacts.openContactPhotoInputStream(cr, Uri.parse(url));
                         }
                         else {
-                            URL u = new URL(url);
-                            HttpURLConnection urlConnection = (HttpURLConnection)u.openConnection();
-                            
+                            final URL u = new URL(url);
+                            final HttpURLConnection urlConnection = (HttpURLConnection)u.openConnection();
+
                             if (mRequestPropertiesCallback != null) {
-                                ArrayList<NameValuePair> props = mRequestPropertiesCallback.getHeadersForRequest(context, url);
+                                final ArrayList<NameValuePair> props = mRequestPropertiesCallback.getHeadersForRequest(context, url);
                                 if (props != null) {
-                                    for (NameValuePair pair: props) {
+                                    for (final NameValuePair pair: props) {
                                         urlConnection.addRequestProperty(pair.getName(), pair.getValue());
                                     }
                                 }
                             }
 
-                            if (urlConnection.getResponseCode() != HttpURLConnection.HTTP_OK)
+                            if (urlConnection.getResponseCode() != HttpURLConnection.HTTP_OK) {
                                 return null;
+                            }
                             is = urlConnection.getInputStream();
                         }
-                        
+
                         if (is != null) {
-                            FileOutputStream fos = new FileOutputStream(filename);
+                            final FileOutputStream fos = new FileOutputStream(filename);
                             copyStream(is, fos);
                             fos.close();
                             is.close();
@@ -402,13 +617,14 @@ public final class UrlImageViewHelper {
                         loader.run();
                         return null;
                     }
-                    catch (Throwable e) {
+                    catch (final Throwable e) {
                         e.printStackTrace();
                         return null;
                     }
                 }
 
-                protected void onPostExecute(Void result) {
+                @Override
+                protected void onPostExecute(final Void result) {
                     completion.run();
                 }
             };
@@ -416,29 +632,30 @@ public final class UrlImageViewHelper {
             executeTask(downloader);
         }
     };
-    
-    static public interface RequestPropertiesCallback {
+
+    public static interface RequestPropertiesCallback {
         public ArrayList<NameValuePair> getHeadersForRequest(Context context, String url);
     }
-    
-    static private RequestPropertiesCallback mRequestPropertiesCallback;
-    static public RequestPropertiesCallback getRequestPropertiesCallback() {
+
+    private static RequestPropertiesCallback mRequestPropertiesCallback;
+
+    public static RequestPropertiesCallback getRequestPropertiesCallback() {
         return mRequestPropertiesCallback;
     }
-    
-    static public void setRequestPropertiesCallback(RequestPropertiesCallback callback) {
+
+    public static void setRequestPropertiesCallback(final RequestPropertiesCallback callback) {
         mRequestPropertiesCallback = callback;
     }
-    
-    
-    public static void useDownloader(UrlDownloader downloader) {
+
+
+    public static void useDownloader(final UrlDownloader downloader) {
         mDownloader = downloader;
     }
 
     public static void useDefaultDownloader() {
         mDownloader = mDefaultDownloader;
     }
-    
+
     public static UrlDownloader getDefaultDownloader() {
         return mDownloader;
     }
@@ -447,12 +664,12 @@ public final class UrlImageViewHelper {
 
     private static UrlLruCache mDeadCache;
     private static HashSet<BitmapDrawable> mAllCache = new HashSet<BitmapDrawable>();
-    private static int getHeapSize(Context context) {
+    private static int getHeapSize(final Context context) {
         return ((ActivityManager)context.getSystemService(Context.ACTIVITY_SERVICE)).getMemoryClass() * 1024 * 1024;
     }
-    
+
     private static class ZombieDrawable extends WrapperDrawable {
-        public ZombieDrawable(String url, BitmapDrawable drawable) {
+        public ZombieDrawable(final String url, final BitmapDrawable drawable) {
             super(drawable);
             mUrl = url;
 
@@ -460,9 +677,9 @@ public final class UrlImageViewHelper {
             mDeadCache.remove(url);
             mLiveCache.put(url, this);
         }
-        
+
         String mUrl;
-        
+
         @Override
         protected void finalize() throws Throwable {
             super.finalize();
@@ -470,24 +687,25 @@ public final class UrlImageViewHelper {
             mDeadCache.put(mUrl, mDrawable);
             mAllCache.remove(mDrawable);
             mLiveCache.remove(mUrl);
-            if (Constants.LOG_ENABLED)
+            if (Constants.LOG_ENABLED) {
                 Log.i(Constants.LOGTAG, "Zombie GC event");
+            }
             System.gc();
         }
     }
 
-
     private static UrlDownloader mDownloader = mDefaultDownloader;
 
-    private static void executeTask(AsyncTask<Void, Void, Void> task) {
-        if (Build.VERSION.SDK_INT < Constants.HONEYCOMB)
+    private static void executeTask(final AsyncTask<Void, Void, Void> task) {
+        if (Build.VERSION.SDK_INT < Constants.HONEYCOMB) {
             task.execute();
-        else
+        } else {
             executeTaskHoneycomb(task);
+        }
     }
-    
+
     @TargetApi(Constants.HONEYCOMB)
-    private static void executeTaskHoneycomb(AsyncTask<Void, Void, Void> task) {
+    private static void executeTaskHoneycomb(final AsyncTask<Void, Void, Void> task) {
         task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }
 

--- a/res/.gitignore
+++ b/res/.gitignore
@@ -1,0 +1,2 @@
+bin
+.settings

--- a/res/.gitignore
+++ b/res/.gitignore
@@ -1,2 +1,0 @@
-bin
-.settings


### PR DESCRIPTION
I minimized the formatting changes, so it won't cause diff to freak out. I started adding documentation to  setUrlDrawable, and I got rid of two warnings: one regarding the deprecation of `Display.get[Width|Height]()` and one regarding the use of `Void[]` rather than `Void...` in an overridden `AsyncTask` method.
