### PR TITLE
Ability to get the underlying BitmapDrawable resource

### DIFF
--- a/UrlImageViewHelper/src/com/koushikdutta/urlimageviewhelper/UrlImageViewHelper.java
+++ b/UrlImageViewHelper/src/com/koushikdutta/urlimageviewhelper/UrlImageViewHelper.java
@@ -404,7 +404,6 @@ public final class UrlImageViewHelper {
      *            called when the image successfully finishes loading. This
      *            value can be null.
      */
-    @SuppressWarnings("deprecation")
     private static void setUrlDrawable(final Context context, final ImageView imageView, final String url, final Drawable defaultDrawable, final long cacheDurationMs, final UrlImageViewCallback callback) {
         cleanup(context);
         // disassociate this ImageView from any pending downloads

--- a/UrlImageViewHelper/src/com/koushikdutta/urlimageviewhelper/WrapperDrawable.java
+++ b/UrlImageViewHelper/src/com/koushikdutta/urlimageviewhelper/WrapperDrawable.java
@@ -48,7 +48,6 @@ class WrapperDrawable extends Drawable {
     
     @Override
     public int getIntrinsicWidth() {
-        // TODO Auto-generated method stub
         return mDrawable.getIntrinsicWidth();
     }
 }

--- a/UrlImageViewHelper/src/com/koushikdutta/urlimageviewhelper/WrapperDrawable.java
+++ b/UrlImageViewHelper/src/com/koushikdutta/urlimageviewhelper/WrapperDrawable.java
@@ -50,4 +50,12 @@ class WrapperDrawable extends Drawable {
     public int getIntrinsicWidth() {
         return mDrawable.getIntrinsicWidth();
     }
+    
+    /**
+     * Returns the underlying {@link BitmapDrawable}.
+     * @return An instance of {@link BitmapDrawable}
+     */
+    public BitmapDrawable toBitmapDrawable() {
+    	return mDrawable;
+    }
 }


### PR DESCRIPTION
There was this problem where I needed to get access to the underlying `BitmapDrawable` for executing `bitmapDrawable.getBitmap()` to write the picture to permanent storage.

For this I added a `toBitmapDrawable()` method in the `WrapperDrawable` class.
Please review.

~Chris

Aah, I fixed some minor, just annoying warnings. But they don't really count I guess.
