### PR TITLE
Make the class WrapperDrawable public available

### DIFF
--- a/UrlImageViewHelper/src/com/koushikdutta/urlimageviewhelper/WrapperDrawable.java
+++ b/UrlImageViewHelper/src/com/koushikdutta/urlimageviewhelper/WrapperDrawable.java
@@ -5,7 +5,7 @@ import android.graphics.ColorFilter;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 
-class WrapperDrawable extends Drawable {
+public class WrapperDrawable extends Drawable {
     public WrapperDrawable(BitmapDrawable drawable) {
         mDrawable = drawable;
     }


### PR DESCRIPTION
Make the class `WrapperDrawable` public accessible, else the getter which returns the underlying resource would be useless.

Appendix to https://github.com/koush/UrlImageViewHelper/pull/25 .

~Chris
