### PR TITLE
Closing FileInputStream.

### DIFF
--- a/UrlImageViewHelper/src/com/koushikdutta/urlimageviewhelper/UrlImageViewHelper.java
+++ b/UrlImageViewHelper/src/com/koushikdutta/urlimageviewhelper/UrlImageViewHelper.java
@@ -73,10 +73,11 @@ public final class UrlImageViewHelper {
 
 //        Log.v(Constants.LOGTAG,targetWidth);
 //        Log.v(Constants.LOGTAG,targetHeight);
+        FileInputStream stream = null;
         try {
             BitmapFactory.Options o = new BitmapFactory.Options();
             o.inJustDecodeBounds = true;
-            FileInputStream stream = new FileInputStream(filename);
+            stream = new FileInputStream(filename);
             BitmapFactory.decodeStream(stream, null, o);
             stream.close();
             stream = new FileInputStream(filename);
@@ -92,6 +93,14 @@ public final class UrlImageViewHelper {
             return new ZombieDrawable(url, bd);
         } catch (final IOException e) {
             return null;
+        } finally {
+            if (stream != null) {
+                try {
+                    stream.close();
+                } catch (IOException e) {
+                    Log.w(Constants.LOGTAG, "Failed to close FileInputStream", e);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Was getting the following from StrictMode:

E/StrictMode(  878): java.lang.Throwable: Explicit termination method 'close' not called
E/StrictMode(  878):    at dalvik.system.CloseGuard.open(CloseGuard.java:184)
E/StrictMode(  878):    at java.io.FileInputStream.<init>(FileInputStream.java:80)
E/StrictMode(  878):    at java.io.FileInputStream.<init>(FileInputStream.java:105)
E/StrictMode(  878):    at com.koushikdutta.urlimageviewhelper.UrlImageViewHelper.loadDrawableFromStream(UrlImageViewHelper.java:82)
E/StrictMode(  878):    at com.koushikdutta.urlimageviewhelper.UrlImageViewHelper.access$6(UrlImageViewHelper.java:71)
E/StrictMode(  878):    at com.koushikdutta.urlimageviewhelper.UrlImageViewHelper$2.run(UrlImageViewHelper.java:492)
E/StrictMode(  878):    at com.koushikdutta.urlimageviewhelper.UrlImageViewHelper$4.doInBackground(UrlImageViewHelper.java:540)
E/StrictMode(  878):    at com.koushikdutta.urlimageviewhelper.UrlImageViewHelper$4.doInBackground(UrlImageViewHelper.java:1)

Added a finally block to the method to always at least try to close out the stream.
