### PR TITLE
Fix issue with ZombieDrawable#getBounds

### DIFF
--- a/UrlImageViewHelper/src/com/koushikdutta/urlimageviewhelper/WrapperDrawable.java
+++ b/UrlImageViewHelper/src/com/koushikdutta/urlimageviewhelper/WrapperDrawable.java
@@ -2,6 +2,7 @@ package com.koushikdutta.urlimageviewhelper;
 
 import android.graphics.Canvas;
 import android.graphics.ColorFilter;
+import android.graphics.Rect;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 
@@ -39,6 +40,13 @@ public class WrapperDrawable extends Drawable {
     @Override
     public void setBounds(int left, int top, int right, int bottom) {
         mDrawable.setBounds(left, top, right, bottom);
+        super.setBounds(left, top, right, bottom);
+    }
+    
+    @Override
+    public void setBounds(Rect r) {
+        mDrawable.setBounds(r);
+        super.setBounds(r);
     }
     
     @Override


### PR DESCRIPTION
This was resulting in an issue where getBounds() was not returning the
correct response for ZombieDrawable instances because a call to the
ZombieDrawable#setBounds passed directly to the wrapped Drawable, but
getBounds on the same instance called from the super class instead.

For example, if one had the code

``` java
Drawable zd = new ZombieDrawable(bitmapDrawable);
zd.setBounds(0, 0, 48, 48);
zd.getBounds(new Rect())
```

The getBounds call would not populate the rect with 0,0 48x48. this can't be fixed by overriding the getBounds call because it appears that those are marked as `final` according to the [javadocs](https://developer.android.com/reference/android/graphics/drawable/Drawable.html)  :(.

This manifested as a problem because i was attempting to use a Compound Drawable on a textview, which pulls it's size information from getBounds().
