### PR TITLE
Disable disk cache for Content Scheme Url 

### DIFF
--- a/UrlImageViewHelper/src/com/koushikdutta/urlimageviewhelper/UrlImageViewHelper.java
+++ b/UrlImageViewHelper/src/com/koushikdutta/urlimageviewhelper/UrlImageViewHelper.java
@@ -172,8 +172,6 @@ public final class UrlImageViewHelper {
         // Log.v(Constants.LOGTAG,targetWidth);
         // Log.v(Constants.LOGTAG,targetHeight);
         clog("Decoding: " + url + ", filename=" + filename);
-        android.util.Log.i("nora", "loadDrawableFromLocalUrl " + url + ", w=" + targetWidth + ", h=" + targetHeight
-                + ", filename=" + filename);
         InputStream is = null;
         try {
             is = getInputStreamFromUrlOrFilename(context, url, filename);
@@ -183,7 +181,6 @@ public final class UrlImageViewHelper {
             final Bitmap bitmap;
             if (is instanceof FileInputStream) {
                 FileDescriptor fd = ((FileInputStream) is).getFD();
-                android.util.Log.i("nora", "loadDrawableFromLocalUrl is=" + is + ", fd=" + fd);
                 Options o = null;
                 if (mUseBitmapScaling) {
                     o = new Options();
@@ -193,7 +190,6 @@ public final class UrlImageViewHelper {
                 }
                 bitmap = BitmapFactory.decodeFileDescriptor(fd, null, o);
             } else {
-                android.util.Log.i("nora", "loadDrawableFromLocalUrl stream " + is);
                 Options o = null;
                 if (mUseBitmapScaling) {
                     o = new Options();
@@ -210,7 +206,6 @@ public final class UrlImageViewHelper {
                 bitmap = BitmapFactory.decodeStream(is, null, o);
             }
             if (bitmap == null) {
-                android.util.Log.i("nora", "loadDrawableFromLocalUrl bitmap " + bitmap);
                 return null;
             } else {
                 clog(String.format("Loaded bitmap (%dx%d).", bitmap.getWidth(), bitmap.getHeight()));


### PR DESCRIPTION
Disable disk cache for Content Scheme Url 
(except ContactsContract.Contacts.CONTENT_URI)

if url starts with content scheme, set filename and file to null then
mDefaultDownloader.download() -> just call loader.run() -> loadDrawableFromUrl()
