### PR TITLE
Fixing java.util.concurrent.RejectedExecutionException

### DIFF
--- a/UrlImageViewHelper/src/com/koushikdutta/urlimageviewhelper/UrlImageViewHelper.java
+++ b/UrlImageViewHelper/src/com/koushikdutta/urlimageviewhelper/UrlImageViewHelper.java
@@ -666,7 +666,15 @@ public final class UrlImageViewHelper {
         
         for (UrlDownloader downloader: mDownloaders) {
             if (downloader.canDownloadUrl(url)) {
-                downloader.download(context, url, filename, loader, completion);
+                try {
+                    downloader.download(context, url, filename, loader, completion);
+                } catch (Exception e) {
+                    clog("Can't download from url: " + url + " Exception: " + e.getMessage());
+                    mPendingDownloads.remove(url);
+                    if (imageView != null) {
+                        mPendingViews.remove(imageView);
+                    }
+                }
                 return;
             }
         }


### PR DESCRIPTION
Fixing a crash when a download task is rejected from the tread pool.

java.util.concurrent.RejectedExecutionException: Task android.os.AsyncTask$3@42dcacb0 rejected from java.util.concurrent.ThreadPoolExecutor@420cbee0[Running, pool size = 9, active threads = 9, queued tasks = 128, completed tasks = 55]
       at java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.java:2011)
       at java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:793)
       at java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1339)
       at android.os.AsyncTask.executeOnExecutor(AsyncTask.java:590)
       at com.koushikdutta.urlimageviewhelper.UrlImageViewHelper.executeTaskHoneycomb(SourceFile:805)
       at com.koushikdutta.urlimageviewhelper.UrlImageViewHelper.executeTask(SourceFile:799)
       at com.koushikdutta.urlimageviewhelper.HttpUrlDownloader.download(SourceFile:76)
       at com.koushikdutta.urlimageviewhelper.UrlImageViewHelper.setUrlDrawable(SourceFile:669)
       at com.koushikdutta.urlimageviewhelper.UrlImageViewHelper.setUrlDrawable(SourceFile:157)
